### PR TITLE
feat：数字员工注销若曾被任意用户设为默认助理，回退到各自超级助手，避免“默认指向已注销资源”。

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
@@ -808,8 +808,9 @@ public class DigitalEmployeeApplicationService {
     /**
      * 数字员工注销/删除后，把所有把它设为默认助理的用户回退到各自的超级助手；找不到超级助手时清空。
      * 同时若当前登录用户在受影响列表里，需要刷新 session 中的 defaultDigEmployeeId。
+     * 暴露为 public 以便其他注销链路（如 ToolManService.deleteManagedResource）复用。
      */
-    private void resetDefaultForAffectedUsers(Long resourceId) {
+    public void resetDefaultForAffectedUsers(Long resourceId) {
         if (resourceId == null) {
             return;
         }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/state/domain/resource/service/ToolManService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/state/domain/resource/service/ToolManService.java
@@ -47,6 +47,7 @@ import com.iwhalecloud.byai.manager.domain.auth.enums.GrantToObjType;
 import com.iwhalecloud.byai.manager.domain.auth.enums.OperType;
 import com.iwhalecloud.byai.manager.domain.auth.service.PrivilegeGrantService;
 import com.iwhalecloud.byai.manager.application.service.auth.AuthApplicationService;
+import com.iwhalecloud.byai.manager.application.service.digitemploy.DigitalEmployeeApplicationService;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.event.DigEmployeeChangeEventPublisher;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.event.DigEmployeeChangeEventType;
 import com.iwhalecloud.byai.manager.entity.auth.PrivilegeGrant;
@@ -175,6 +176,9 @@ public class ToolManService {
 
     @Autowired
     private ResourceDiscoveryRegistrationService resourceDiscoveryRegistrationService;
+
+    @Autowired
+    private DigitalEmployeeApplicationService digitalEmployeeApplicationService;
 
     @Autowired
     private ResourceRuntimeInfoResolver resourceRuntimeInfoResolver;
@@ -1245,6 +1249,8 @@ public class ToolManService {
         // 7. 若是数字员工，删除后同步清理其技能 Redis 缓存。
         removeDigEmployeeFromRedisIfNecessary(resourceId, resourceBizType);
         if (StringUtils.equals(resourceBizType, ResourceBizType.DIG_EMPLOYEE.getCode())) {
+            // 数字员工注销若曾被任意用户设为默认助理，回退到各自超级助手，避免“默认指向已注销资源”。
+            digitalEmployeeApplicationService.resetDefaultForAffectedUsers(resourceId);
             digEmployeeChangeEventPublisher.publishNowQuietly(DigEmployeeChangeEventType.DIG_EMPLOYEE_DELETED,
                 resourceId, "tool-man-service");
         }
@@ -1280,6 +1286,8 @@ public class ToolManService {
         ssResourceService.removeById(resourceId);
         removeDigEmployeeFromRedisIfNecessary(resourceId, resourceBizType);
         if (StringUtils.equals(resourceBizType, ResourceBizType.DIG_EMPLOYEE.getCode())) {
+            // 硬删除也需要回退默认助理指向，避免遗留无效引用。
+            digitalEmployeeApplicationService.resetDefaultForAffectedUsers(resourceId);
             digEmployeeChangeEventPublisher.publishNowQuietly(DigEmployeeChangeEventType.DIG_EMPLOYEE_DELETED,
                 resourceId, "tool-man-service-hard-delete");
         }

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/state/domain/resource/service/ToolManServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/state/domain/resource/service/ToolManServiceTest.java
@@ -5,6 +5,7 @@ import com.iwhalecloud.byai.common.login.auth.CurrentUserHolder;
 import com.iwhalecloud.byai.common.login.bean.LoginInfo;
 import com.iwhalecloud.byai.common.util.RedisUtil;
 import com.iwhalecloud.byai.manager.application.service.auth.AuthApplicationService;
+import com.iwhalecloud.byai.manager.application.service.digitemploy.DigitalEmployeeApplicationService;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.event.DigEmployeeChangeEventPublisher;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.event.DigEmployeeChangeEventType;
 import com.iwhalecloud.byai.manager.domain.auth.service.PrivilegeGrantService;
@@ -73,6 +74,7 @@ class ToolManServiceTest {
         DigEmployeeChangeEventPublisher digEmployeeChangeEventPublisher = mock(DigEmployeeChangeEventPublisher.class);
         SsResExtDigEmployeeService ssResExtDigEmployeeService = mock(SsResExtDigEmployeeService.class);
         ResourceDiscoveryRegistrationService resourceDiscoveryRegistrationService = mock(ResourceDiscoveryRegistrationService.class);
+        DigitalEmployeeApplicationService digitalEmployeeApplicationService = mock(DigitalEmployeeApplicationService.class);
 
         ReflectionTestUtils.setField(service, "ssResourceService", ssResourceService);
         ReflectionTestUtils.setField(service, "authApplicationService", authApplicationService);
@@ -83,6 +85,7 @@ class ToolManServiceTest {
         ReflectionTestUtils.setField(service, "digEmployeeChangeEventPublisher", digEmployeeChangeEventPublisher);
         ReflectionTestUtils.setField(service, "ssResExtDigEmployeeService", ssResExtDigEmployeeService);
         ReflectionTestUtils.setField(service, "resourceDiscoveryRegistrationService", resourceDiscoveryRegistrationService);
+        ReflectionTestUtils.setField(service, "digitalEmployeeApplicationService", digitalEmployeeApplicationService);
         ReflectionTestUtils.setField(service, "datasetSystem", "");
         prepareRedisUtil();
 


### PR DESCRIPTION
## Summary

<!-- Short description of the change and motivation -->

## Checklist

- [ ] Tests added or updated (as appropriate for the change)
- [ ] Documentation updated under `docs/` or the relevant module (if applicable)
- [ ] Local **lint / tests** run where relevant
- [ ] **No secrets** (tokens, keys, internal-only URLs or configs)

## Related issues

<!-- e.g. Closes #123 -->
