### PR TITLE
docs: correct module setup info in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,10 @@ Thank you for contributing to Byclaw.
 1. Clone the repository.
 2. Initialize each module you work on (see its README):
    - `byclaw-fe/`: Node.js and `pnpm` (or npm as documented there).
-   - `byclaw-be/`: JDK 17+ and Maven.
-   - `byclaw-exe/`: Python 3.10+ with `uv` or `pip` in a virtual environment.
+   - `byclaw-be/`: JDK 21+ and Maven (enforced via maven-enforcer; the code uses Java 21 features).
+   - `byclaw-exe/`: see the module README for setup.
+   - `byclaw-data/`: Python 3.12+ with `uv` (see module README).
+   - `byclaw-qa/`: Python 3.12+ with `uv` (see module README).
 
 ## Style and commits
 


### PR DESCRIPTION
The "Development setup" section in CONTRIBUTING.md had a few inaccuracies that can mislead new contributors setting up their environment:

- `byclaw-be` was listed as "JDK 17+", but it actually requires JDK 21+: maven-enforcer enforces `[21,)`, the compiler release is 21, and the source uses Java 21 syntax (record types, switch patterns). Building with JDK 17 fails.
- `byclaw-data` and `byclaw-qa` (both Python 3.12+ with `uv`) were missing from the module list.
- `byclaw-exe` was listed as "Python 3.10+", but the directory currently contains TypeScript. Since its README still describes it as Python, I did not assert a language here and instead defer to the module README, to avoid making an assumption about the intended setup. Happy to update this if a maintainer clarifies the intended language for byclaw-exe.

Docs-only change; no code or CI impact.