### PR TITLE
fix(ci): pin mypy to an exact version in byclaw-data

### DIFF
--- a/byclaw-data/pyproject.toml
+++ b/byclaw-data/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "httpx==0.27",
     "ruff==0.8",
     "pytest-asyncio==1.3.0",
-    "mypy>=1.13",
+    "mypy==1.13",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
The `version-pinning` CI job requires every dependency to use an exact version, but `byclaw-data/pyproject.toml` had `mypy>=1.13` in its dev dependencies while every other dependency in the file uses `==` (e.g. `pytest==8.0`, `ruff==0.8`).

This single unpinned entry is what fails the `version-pinning` check. Pinning it to `==1.13` keeps the same version, matches the style of the rest of the file, and satisfies the check.

I verified locally by re-running the version-pinning script from `ci.yml` against all `pyproject.toml` / `package.json` files — after this change it reports no unpinned dependencies.

Docs/tooling-only change; `mypy` is a dev-time type checker, so there is no runtime impact.