### PR TITLE
docs: correct required JDK version in byclaw-be README

### DIFF
--- a/byclaw-be/README.md
+++ b/byclaw-be/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/byclaw/byclaw-be/actions/workflows/ci.yml/badge.svg)](https://github.com/byclaw/byclaw-be/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Java](https://img.shields.io/badge/Java-17%2B-orange)](https://openjdk.org/)
+[![Java](https://img.shields.io/badge/Java-21%2B-orange)](https://openjdk.org/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.x-brightgreen)](https://spring.io/projects/spring-boot)
 
 ## 简介
@@ -159,7 +159,7 @@ byclaw-be/
 
 ### 环境要求
 
-- Java 17+
+- Java 21+
 - Maven 3.8+
 - MySQL 8.0+ / PostgreSQL / OpenGauss
 - Redis 5.0+


### PR DESCRIPTION
The `byclaw-be` README still lists Java 17+, but the module actually requires JDK 21:

- `maven-enforcer-plugin` enforces `[21,)` (build fails on anything below 21)
- the compiler `release`/`source`/`target` are all set to 21
- the source uses Java 21 syntax (e.g. records), which won't compile under 17

This PR updates the two remaining spots in `byclaw-be/README.md` — the Java badge and the "环境要求" prerequisites — from 17+ to 21+.

This is the same correction already merged for the root `CONTRIBUTING.md` in #145; this PR brings the module README in line with it.

Docs-only change.