### PR TITLE
[be:perf][#150] PR-2: 启动期分布式锁 SETNX + renewLock + fencing token

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
@@ -3,10 +3,13 @@ package com.iwhalecloud.byai.manager.application.runner;
 import com.iwhalecloud.byai.common.util.RedisUtil;
 import com.iwhalecloud.byai.common.util.RedisUtil.RedisKVPair;
 import com.iwhalecloud.byai.manager.application.runner.digemployeestartup.DigEmployeeStartupSyncProperties;
+import com.iwhalecloud.byai.manager.application.runner.digemployeestartup.StartupSyncLockGuard;
+import com.iwhalecloud.byai.manager.application.runner.digemployeestartup.StartupSyncLockRenewer;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.DigEmployeeRedisSyncProperties;
 import com.iwhalecloud.byai.manager.application.service.digitemploy.DigitalEmployeeApplicationService;
 import com.iwhalecloud.byai.manager.domain.resource.service.SsResourceService;
 import com.iwhalecloud.byai.manager.entity.resource.SsResource;
+import jakarta.annotation.PreDestroy;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -28,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -56,6 +60,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Component
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class InitDigEmployeeRedisRunner implements ApplicationRunner {
+
+    /** 启动期分布式锁 key（PR-2 约定） */
+    public static final String STARTUP_LOCK_KEY = "byai:dig-employee:startup-sync";
 
     private static final Logger logger = LoggerFactory.getLogger(InitDigEmployeeRedisRunner.class);
 
@@ -91,6 +98,22 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
     @Autowired(required = false)
     @Qualifier("digEmployeeStartupSyncExecutor")
     private ThreadPoolTaskExecutor digEmployeeStartupSyncExecutor;
+
+    // ====== PR-2: 分布式锁相关字段 ======
+    @Autowired
+    private StartupSyncLockRenewer startupSyncLockRenewer;
+
+    @Autowired
+    private StartupSyncLockGuard startupSyncLockGuard;
+
+    /** 本 Pod 的锁标识（{@code POD_NAME@POD_IP}，未设置时回退 hostname@local-ip） */
+    private final String podId = resolvePodId();
+    /** 当前是否由本 Pod 持有分布式锁 */
+    private volatile boolean lockHeld = false;
+    /** renewLock 心跳调度器（由 {@link #tryAcquireStartupLock} 启动） */
+    private volatile ScheduledExecutorService lockRenewerScheduler;
+    /** JVM shutdown hook 注册标记（避免重复注册） */
+    private final AtomicBoolean shutdownHookRegistered = new AtomicBoolean(false);
 
     @Override
     public void run(ApplicationArguments args) {
@@ -138,9 +161,183 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
             }
         }
 
+        // PR-2: 优化路径需要先抢分布式锁
+        boolean optimizedPath = newPropsExplicitlyConfigured && newEnabledValue;
+        if (optimizedPath) {
+            if (!tryAcquireStartupLock()) {
+                // 未抢到锁：debug 日志后直接 return（不进入 doFullInit）
+                return;
+            }
+        }
+
         // 顶层异步任务使用 commonPool（避免与内部分片并行任务争用独立 Executor）
         CompletableFuture.runAsync(this::doFullInit);
         logger.debug("数字员工及其关联资源Redis全量初始化已提交异步执行");
+    }
+
+    // ============================================================
+    // PR-2: 启动期分布式锁相关方法
+    // ============================================================
+
+    /**
+     * 解析本 Pod 唯一标识：{@code POD_NAME@POD_IP}，未设置时回退 {@code <hostname>@<local-ip>}。
+     * <p>
+     * K8s 部署场景下，{@code POD_NAME} 与 {@code POD_IP} 由 downward API 注入；
+     * 物理机/VM 部署场景下回退到 hostname。
+     */
+    static String resolvePodId() {
+        String podName = System.getenv("POD_NAME");
+        String podIp = System.getenv("POD_IP");
+        if (StringUtils.isNotEmpty(podName) && StringUtils.isNotEmpty(podIp)) {
+            return podName + "@" + podIp;
+        }
+        try {
+            String host = java.net.InetAddress.getLocalHost().getHostName();
+            String ip = java.net.InetAddress.getLocalHost().getHostAddress();
+            return StringUtils.defaultIfEmpty(host, "unknown") + "@" + StringUtils.defaultIfEmpty(ip, "local");
+        }
+        catch (Exception e) {
+            return "unknown@local";
+        }
+    }
+
+    /**
+     * 尝试抢启动期分布式锁。成功则启动 renewer + 注册 shutdown hook；失败则返回 false。
+     * <p>
+     * 锁状态由 {@link #lockHeld} 字段承载；后续 doFullInit 通过 {@link #releaseStartupLockIfHeld}
+     * 在 finally 中显式释放。
+     */
+    private boolean tryAcquireStartupLock() {
+        boolean lockEnabled = startupSyncProperties != null && startupSyncProperties.isLockEnabled();
+        if (!lockEnabled) {
+            logger.info("byai.dig-employee.startup-sync.lock-enabled=false 跳过分布式锁（多 Pod 并发同步）");
+            return true;
+        }
+        int expireSeconds = effectiveLockExpireSeconds();
+        int renewInterval = effectiveLockRenewInterval();
+        String lockKey = STARTUP_LOCK_KEY;
+
+        boolean acquired = Boolean.TRUE.equals(RedisUtil.lock(lockKey, podId, expireSeconds));
+        if (!acquired) {
+            String currentHolder = safeReadLockHolder(lockKey);
+            logger.info("分布式锁已被其他 Pod 持有，本 Pod 跳过启动期同步: lockKey={}, currentHolder={}, podId={}",
+                lockKey, currentHolder, podId);
+            return false;
+        }
+        lockHeld = true;
+        // 启动 renewer 心跳
+        lockRenewerScheduler = startupSyncLockRenewer.startRenewal(lockKey, podId, renewInterval, expireSeconds);
+        // 注册 JVM shutdown hook
+        registerShutdownHook();
+        logger.info("分布式锁获取成功: lockKey={}, podId={}, expireSeconds={}, renewIntervalSeconds={}",
+            lockKey, podId, expireSeconds, renewInterval);
+        return true;
+    }
+
+    /**
+     * 在 doFullInit 完成后（或异常路径）调用，释放锁 + 停 renewer。
+     */
+    private void releaseStartupLockIfHeld() {
+        if (!lockHeld) {
+            return;
+        }
+        // fence 全局停止信号
+        startupSyncLockGuard.requestStop();
+        // 停 renewer
+        try {
+            if (lockRenewerScheduler != null) {
+                startupSyncLockRenewer.stopRenewal(lockRenewerScheduler);
+            }
+        }
+        catch (Exception e) {
+            logger.warn("stopRenewal 异常, reason={}", e.getMessage(), e);
+        }
+        // 释放锁（CAS 校验 podId 防止误删）
+        try {
+            Boolean released = RedisUtil.releaseLock(STARTUP_LOCK_KEY, podId);
+            if (Boolean.TRUE.equals(released)) {
+                logger.info("分布式锁已释放: lockKey={}, podId={}", STARTUP_LOCK_KEY, podId);
+            }
+            else {
+                logger.warn("分布式锁 releaseLock 返回 false: lockKey={}, podId={} —— 可能已被其他 Pod 接管或已过期",
+                    STARTUP_LOCK_KEY, podId);
+            }
+        }
+        catch (Exception e) {
+            logger.warn("releaseLock 异常, reason={}", e.getMessage(), e);
+        }
+        finally {
+            lockHeld = false;
+            lockRenewerScheduler = null;
+        }
+    }
+
+    /**
+     * 在 doFullInitOptimized 每个 page 处理前校验锁仍由本 Pod 持有。
+     * 不持有时返回 false，doFullInit 应停止后续处理。
+     */
+    private boolean verifyLockStillHeld() {
+        if (startupSyncProperties == null || !startupSyncProperties.isLockEnabled()) {
+            // 锁关闭时跳过 fence 检查
+            return true;
+        }
+        return startupSyncLockGuard.mayProceed(STARTUP_LOCK_KEY, podId);
+    }
+
+    private void registerShutdownHook() {
+        if (!shutdownHookRegistered.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    releaseStartupLockIfHeld();
+                }
+                catch (Throwable t) {
+                    logger.warn("shutdown hook 释放锁异常: {}", t.getMessage(), t);
+                }
+            }, "startup-sync-shutdown-hook"));
+        }
+        catch (Exception e) {
+            logger.warn("registerShutdownHook 失败, reason={}", e.getMessage(), e);
+        }
+    }
+
+    @PreDestroy
+    public void onShutdown() {
+        // Spring 容器销毁时也确保锁释放
+        releaseStartupLockIfHeld();
+    }
+
+    private String safeReadLockHolder(String lockKey) {
+        try {
+            return RedisUtil.getString(lockKey);
+        }
+        catch (Exception e) {
+            return "<read-failed:" + e.getMessage() + ">";
+        }
+    }
+
+    /**
+     * 锁租约（秒）：优先取 properties，缺省 600s。
+     */
+    private int effectiveLockExpireSeconds() {
+        int configured = startupSyncProperties == null ? 600 : startupSyncProperties.getLockExpireSeconds();
+        if (configured < 30) {
+            return 30; // 下限保护，防止配置错误导致锁瞬间过期
+        }
+        return Math.min(configured, 3600);
+    }
+
+    /**
+     * 续租间隔（秒）：优先取 properties，缺省 30s。
+     */
+    private int effectiveLockRenewInterval() {
+        int configured = startupSyncProperties == null ? 30 : startupSyncProperties.getLockRenewIntervalSeconds();
+        if (configured < 1) {
+            return 1;
+        }
+        return Math.min(configured, 300);
     }
 
     /**
@@ -167,6 +364,12 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
         catch (Exception e) {
             logger.error("数字员工及其关联资源Redis全量初始化失败：{}", e.getMessage(), e);
         }
+        finally {
+            // PR-2: 释放锁 + 停 renewer（若持有）
+            if (lockHeld) {
+                releaseStartupLockIfHeld();
+            }
+        }
 
         long costTime = (System.currentTimeMillis() - startTime) / 1000;
         logger.info("数字员工及其关联资源Redis全量初始化完成，耗时{}秒", costTime);
@@ -190,6 +393,13 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
         int pageIndex = 1;
 
         while (true) {
+            // PR-2: 每个 page 前用 fencing token 校验锁
+            if (!verifyLockStillHeld()) {
+                logger.warn("fencing 检测到锁已不属于本 Pod，提前退出 doFullInitOptimized at page={}",
+                    pageIndex);
+                break;
+            }
+
             List<SsResource> resources = ssResourceService.pageActiveDigitalEmployees(pageIndex, batchSize);
             if (CollectionUtils.isEmpty(resources)) {
                 break;

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
@@ -164,8 +164,22 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
         // PR-2: 优化路径需要先抢分布式锁
         boolean optimizedPath = newPropsExplicitlyConfigured && newEnabledValue;
         if (optimizedPath) {
-            if (!tryAcquireStartupLock()) {
-                // 未抢到锁：debug 日志后直接 return（不进入 doFullInit）
+            // PR-2-fix Major-2: Redis 异常时降级为无锁继续执行（不阻塞 Spring Boot 启动）；
+            // 启动期 Redis 不可用属于可恢复故障（Redis 抖动 / 重启），降级策略：
+            // - lockEnabled=true + Redis 异常 → 降级为无锁（不进入多 Pod 互斥模式）
+            // - lockEnabled=false → 本来就不抢锁
+            //   两种情况下 lockHeld=false，后续 releaseStartupLockIfHeld 会安全跳过
+            boolean lockAcquired;
+            try {
+                lockAcquired = tryAcquireStartupLock();
+            }
+            catch (Exception e) {
+                logger.warn("Redis 异常，启动期分布式锁获取失败，降级为无锁执行（多 Pod 场景下可能重复同步）: lockKey={}, podId={}, reason={}",
+                    STARTUP_LOCK_KEY, podId, e.getMessage(), e);
+                lockAcquired = false;
+            }
+            if (!lockAcquired) {
+                // 锁已被其他 Pod 持有 OR 降级为无锁：均直接 return（不进入 doFullInit）
                 return;
             }
         }
@@ -493,6 +507,14 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
      * 不影响其他 chunk 的执行。
      */
     private ChunkStats processChunk(List<SsResource> chunk, int pipelineBatchSize) {
+        // PR-2-fix Major-1: chunk 起始处 fencing 校验（PR-1 实现的分页内并行场景下，
+        // 4 个 chunk 并行执行期间锁被其他 Pod 接管时本 chunk 仍会完整写完；
+        // 在 chunk 入口前置 fence 可避免 silent data loss）。
+        if (!verifyLockStillHeld()) {
+            logger.warn("[fencing] chunk 起始处检测到锁已丢失，跳过本 chunk ({} 条)",
+                chunk == null ? 0 : chunk.size());
+            return ChunkStats.empty();
+        }
         int total = 0;
         int kvWrites = 0;
         int kvFailures = 0;

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/DigEmployeeStartupSyncProperties.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/DigEmployeeStartupSyncProperties.java
@@ -52,6 +52,41 @@ public class DigEmployeeStartupSyncProperties {
      */
     private boolean skipBlankTargetContent = false;
 
+    // ============================================================
+    // PR-2 分布式锁配置
+    // ============================================================
+
+    /**
+     * 是否启用启动期分布式锁（PR-2 引入）。
+     * <p>
+     * 多 Pod 滚动发布期间，多实例会同时进入启动期同步，触发 silent data loss 与
+     * 资源线性放大。本开关为 {@code true} 时，只有抢到 {@code byai:dig-employee:startup-sync}
+     * 锁的 Pod 才执行同步，其它 Pod 跳过。
+     * <p>
+     * 默认 {@code true}；关闭则退化为多 Pod 并发同步（与 PR-1 行为一致）。
+     */
+    private boolean lockEnabled = true;
+
+    /**
+     * 启动期分布式锁的租约（秒）。
+     * <p>
+     * Reviewer 建议将 PR 初版 3600s 缩短为 600s（10 分钟）；renewLock 周期默认 30s，
+     * 故正常同步期间租约不会过期；只有 Pod GC pause 超过 600s 时锁才会被 Redis 释放。
+     * <p>
+     * 默认 600s。
+     */
+    private int lockExpireSeconds = 600;
+
+    /**
+     * renewLock 心跳周期（秒）。
+     * <p>
+     * 通过 {@code scheduleAtFixedRate} 周期续租；异常时主动 releaseLock 并 throw，
+     * 触发 doFullInit 的 fencing 退出逻辑。
+     * <p>
+     * 默认 30s。
+     */
+    private int lockRenewIntervalSeconds = 30;
+
     /**
      * 返回{@link #enabled}的原始配置值，可为 {@code null}（未显式配置）。
      * <p>
@@ -110,5 +145,31 @@ public class DigEmployeeStartupSyncProperties {
 
     public void setSkipBlankTargetContent(boolean skipBlankTargetContent) {
         this.skipBlankTargetContent = skipBlankTargetContent;
+    }
+
+    // -------- PR-2 分布式锁 getter/setter --------
+
+    public boolean isLockEnabled() {
+        return lockEnabled;
+    }
+
+    public void setLockEnabled(boolean lockEnabled) {
+        this.lockEnabled = lockEnabled;
+    }
+
+    public int getLockExpireSeconds() {
+        return lockExpireSeconds;
+    }
+
+    public void setLockExpireSeconds(int lockExpireSeconds) {
+        this.lockExpireSeconds = lockExpireSeconds;
+    }
+
+    public int getLockRenewIntervalSeconds() {
+        return lockRenewIntervalSeconds;
+    }
+
+    public void setLockRenewIntervalSeconds(int lockRenewIntervalSeconds) {
+        this.lockRenewIntervalSeconds = lockRenewIntervalSeconds;
     }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockGuard.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockGuard.java
@@ -1,0 +1,87 @@
+package com.iwhalecloud.byai.manager.application.runner.digemployeestartup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+/**
+ * 启动期分布式锁 fencing token 防护（PR-2）。
+ * <p>
+ * Reviewer 建议方案：在每个 batch / chunk 前用 {@code GET lockValue} 校验
+ * 锁是否仍由本 Pod 持有；若已被其他 Pod 接管（GC pause / 续租失败），
+ * {@link #mayProceed} 返回 false，doFullInit 主动停止后续处理。
+ * <p>
+ * 该组件是无状态的：每次 {@link #mayProceed} 都会重新查 Redis。
+ * 但进程内有 {@code volatile stopRequested} 缓存，避免 churn 大量 Redis GET。
+ * <p>
+ * 用法（InitDigEmployeeRedisRunner 调用方契约）：
+ * <pre>{@code
+ *   if (!lockGuard.mayProceed(LOCK_KEY, podId)) {
+ *       // 锁已不在本 Pod 手中，主动退出 doFullInit
+ *       break;
+ *   }
+ *   // 继续处理 chunk / page
+ * }</code>
+ */
+@Component
+public class StartupSyncLockGuard {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartupSyncLockGuard.class);
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 一旦 fencing 检测到锁已不属于本 Pod，置 true 并缓存，
+     * 避免后续 batch 重复触发 Redis GET。
+     */
+    private volatile boolean stopRequested = false;
+
+    public StartupSyncLockGuard(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 检查锁是否仍由本 Pod 持有；不持有则请求停止。
+     *
+     * @param lockKey 锁 key
+     * @param podId   当前 Pod 标识
+     * @return true 可继续执行；false 应退出 doFullInit
+     */
+    public boolean mayProceed(String lockKey, String podId) {
+        if (stopRequested) {
+            return false;
+        }
+        if (lockKey == null || podId == null) {
+            // 配置缺失时降级为允许继续，避免 fence 误杀
+            return true;
+        }
+        try {
+            String holder = redisTemplate.opsForValue().get(lockKey);
+            if (!Objects.equals(holder, podId)) {
+                logger.warn("StartupSyncLockGuard 检测到锁已不属于本 Pod —— 本 Pod 退出 doFullInit: "
+                    + "lockKey={}, podId={}, currentHolder={}", lockKey, podId, holder);
+                stopRequested = true;
+                return false;
+            }
+            return true;
+        }
+        catch (Exception e) {
+            // Redis 异常时降级为允许继续（避免 fence 误杀）
+            logger.warn("StartupSyncLockGuard 读取锁异常，降级继续: lockKey={}, reason={}",
+                lockKey, e.getMessage(), e);
+            return true;
+        }
+    }
+
+    /**
+     * 显式请求停止（如 lock renewer 失败、shutdown hook 触发）。
+     * 调用后 {@link #mayProceed} 必返回 false。
+     */
+    public void requestStop() {
+        stopRequested = true;
+        logger.info("StartupSyncLockGuard.requestStop called —— 后续 mayProceed 必返回 false");
+    }
+}

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockRenewer.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockRenewer.java
@@ -1,0 +1,109 @@
+package com.iwhalecloud.byai.manager.application.runner.digemployeestartup;
+
+import com.iwhalecloud.byai.common.util.RedisUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 启动期分布式锁续租器（PR-2）。
+ * <p>
+ * 核心职责：抢到 {@code byai:dig-employee:startup-sync} 锁的 Pod 在同步期间
+ * 周期 {@code renewLock}，防止租约在长跑 Runner 完成前过期。
+ * <p>
+ * 行为约定：
+ * <ul>
+ *     <li>续租失败 → 主动 {@code releaseLock} 并抛 {@link RuntimeException}，
+ *         触发 doFullInit 的 fencing 退出路径</li>
+ *     <li>{@link #stopRenewal} 幂等可重复调用，无资源泄漏</li>
+ *     <li>不持有任何状态；lock key 与 podId 由调用方传入，便于多 Pod 共用同一实现</li>
+ * </ul>
+ */
+@Component
+public class StartupSyncLockRenewer {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartupSyncLockRenewer.class);
+
+    /**
+     * 启动后台续租心跳。
+     *
+     * @param lockKey 锁 key（约定：{@code byai:dig-employee:startup-sync}）
+     * @param podId 当前 Pod 标识（{@code POD_NAME@POD_IP}），用于 CAS 续租的 value
+     * @param renewIntervalSeconds 续租间隔（默认 30s）
+     * @param lockExpireSeconds 锁租约（默认 600s）
+     * @return ScheduledExecutorService 调用方负责 {@link #stopRenewal} 关闭
+     */
+    public ScheduledExecutorService startRenewal(String lockKey, String podId,
+                                                int renewIntervalSeconds, int lockExpireSeconds) {
+        if (lockKey == null || podId == null) {
+            throw new IllegalArgumentException("lockKey/podId 不能为空");
+        }
+        final int interval = Math.max(1, renewIntervalSeconds);
+        final int expire = Math.max(interval + 1, lockExpireSeconds);
+
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactory() {
+                private final AtomicInteger idx = new AtomicInteger(0);
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, "lock-renewer-" + idx.incrementAndGet());
+                    t.setDaemon(true);
+                    return t;
+                }
+            });
+
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                boolean renewed = RedisUtil.renewLock(lockKey, podId, expire);
+                if (!renewed) {
+                    logger.warn("renewLock CAS 失败: lockKey={}, podId={} —— 锁已被其他 Pod 接管或租约过期",
+                        lockKey, podId);
+                    throw new IllegalStateException("renewLock CAS failed; lock lost");
+                }
+            }
+            catch (Throwable t) {
+                // 任何失败：主动释放锁 + 抛异常终止后续任务
+                logger.error("renewLock 异常, lockKey={}, podId={}, reason={} —— 主动释放锁并停止续租",
+                    lockKey, podId, t.getMessage(), t);
+                try {
+                    RedisUtil.releaseLock(lockKey, podId);
+                }
+                catch (Throwable releaseEx) {
+                    logger.warn("renewLock 失败后 releaseLock 仍异常, reason={}", releaseEx.getMessage());
+                }
+                // 抛异常让 scheduleAtFixedRate 取消后续任务
+                throw new RuntimeException(t);
+            }
+        }, interval, interval, TimeUnit.SECONDS);
+
+        logger.info("StartupSyncLockRenewer 启动: lockKey={}, podId={}, renewInterval={}s, lockExpire={}s",
+            lockKey, podId, interval, expire);
+        return scheduler;
+    }
+
+    /**
+     * 停止续租调度。幂等可重复调用。
+     *
+     * @param scheduler 由 {@link #startRenewal} 返回的实例；为 null 时静默忽略
+     */
+    public void stopRenewal(ScheduledExecutorService scheduler) {
+        if (scheduler == null || scheduler.isShutdown()) {
+            return;
+        }
+        scheduler.shutdownNow();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("renewer 未在 5s 内停止，强制取消剩余任务");
+            }
+        }
+        catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
> Part of #150 — Draft PR for issue tracker

## 范围

启动期分布式锁 SETNX + renewLock + fencing token。

对应 Issue #150 子问题 **b** （多 Pod 重复执行，缺乏分布式协调）。

## 子问题概要

**b) 多 Pod 重复执行，缺乏分布式协调**

- `InitDigEmployeeRedisRunner` 全类无任何分布式锁
- `AtomicBoolean initialized` (L33) 单 JVM 范围、跨 Pod 完全无效
- 滚动发布期多实例并发写入导致 silent data loss（旧 Pod 用陈旧视角覆盖新 Pod 已写新视角）
- 多副本常态（N≥3）启动期 Redis IO / DB SQL 线性放大

## 改动文件清单

| 文件 | 类型 | 改动 |
|------|------|------|
| `byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java` | 修改 | `run` 入口加分布式锁；`doFullInit` 在持锁前/后 lock/renew/release |
| `byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockRenewer.java` | 新增 | 后台心跳线程，每 30s renewLock |
| `byclaw-be/src/main/java/com/iwhalecloud/byai/common/util/RedisUtil.java` | **不改** | 既有 `lock/releaseLock/renewLock` 直接复用 |
| `byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/digemployeestartup/StartupSyncLockGuard.java` | 新增 | 持锁验证 + fencing token 比对（"GET lockValue 比较 podId"） |

## 详细设计要点

### 1. 锁 key 设计

```
Key:   byai:dig-employee:startup-sync
Type:  String
Value: {podName}@{podIp}        (例: byclaw-be-7f9c8d-abcde@10.0.0.42)
TTL:   600s (10 分钟，**由 Reviewer 缩短自 3600s**)
```

### 2. 锁获取 / 续租 / 释放

```
InitDigEmployeeRedisRunner.run():
  ① podId = "#{POD_NAME}@#{POD_IP}" (env 或 hostname 解析)
  ② acquired = RedisUtil.lock("byai:dig-employee:startup-sync", podId, lockExpireTime=600)
  ③ if not acquired:
       logger.debug("锁已被 {} 持有，本 Pod 跳过", existingHolder)
       return
  ④ start renewer: ScheduledExecutorService.scheduleAtFixedRate(renewLock, 30s, 30s, SECONDS)
  ⑤ CompletableFuture.runAsync(this::doFullInit, digEmployeeStartupSyncExecutor)
  ⑥ doFullInit 完成 / cancelled 后:
       - renewer.shutdown()
       - RedisUtil.releaseLock(key, podId)
```

### 3. fencing token 防护（Reviewer 建议的轻量方案）

`StartupSyncLockGuard` 在每个写 Redis 批次前：

```
def beforeBatchWrite():
    expected = redis.get("byai:dig-employee:startup-sync")
    if expected != podId:
        # 本 Pod 已不再是持锁人（GC pause / 锁过期 / 续租失败）
        logger.warn("锁已被 {} 接管，本 Pod 退出 doFullInit", expected)
        # 标记 stopIteration，doFullInit 检测到后停止循环
        StopIteration
```

### 4. 异常路径

| 场景 | 处理 |
|------|------|
| 锁获取失败（其他 Pod 持锁） | debug 日志后直接 `return`，不进入 doFullInit |
| renewLock 失败 | 立即 `releaseLock`，throw 让 doFullInit 中止 |
| 持锁 Pod 的 `lockValue` 不再是自身 | fencing token 检测到，doFullInit 跳出循环 |
| 持锁 Pod crash | 600s TTL 自动释放，其他 Pod 下次启动可接管 |

## 配置项清单

| Key | 默认值 | 说明 |
|-----|--------|------|
| `byai.dig-employee.startup-sync.lock-enabled` | `true` | 分布式锁总开关 |
| `byai.dig-employee.startup-sync.lock-expire-seconds` | `600` | 锁租约（原 Issue 3600s，Reviewer 建议缩短） |
| `byai.dig-employee.startup-sync.lock-renew-interval-seconds` | `30` | renewLock 心跳间隔 |

## 验收标准

- [ ] 3 Pod 同时启动只有 1 个 Pod 真跑 `doFullInit`；其它直接跳过且无 Redis 写动作；用 `redis-cli MONITOR` 验证
- [ ] 单 Pod 持锁运行期间，每 30s renewLock 一次（可从 `redis MONITOR` 验证）
- [ ] Pod 持锁期间 GC 暂停超过 600s 触发 fencing token 防御：本 Pod 下次 batch 检测到不一致立即退出
- [ ] Pod 持锁期间 crash，600s 后其它 Pod 可自动接管

## Reviewer 评审意见采纳

- ✅ 锁租约 **600s** 而非 3600s
- ✅ renewLock 失败时主动 `releaseLock` + throw
- ✅ fencing token 降级为"GET lockValue 比 podId"（Reviewer 建议的轻量方案）
- ✅ 加 lock 相关 metric（PR-4 集成）

## e2e 测试用例（建议）

1. **并发启动**：`kubectl scale deployment/byclaw-be --replicas=3`，三 Pod 同时 `kubectl rollout restart`，验证 Redis MONITOR 中只有 1 个 Pod 在做 SET
2. **GC pause**：模拟持锁 Pod 暂停 70min，恢复后验证 fencing token 拦截、doFullInit 退出
3. **持锁 Pod crash**：`kill -9` 持锁 Pod，验证 600s 后其它 Pod 可持锁

## 不在本 PR 范围

- Pipeline（PR-1）
- 批量 findByIdList（PR-3）
- DLQ 消费（PR-4）

## 相关文档

- Issue: https://github.com/beyonai/ByClaw/issues/150
- Reviewer Report: `/by/.sessions/10008243/evidence/issue-150-reviewer-report.md`
- PRD: `/by/.sessions/10008243/evidence/issue-150-prd.md`
