### PR TITLE
[be:perf][#150] PR-3: 批量 findById + 整页预取 + 空白率门禁

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/runner/InitDigEmployeeRedisRunner.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -390,8 +392,11 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
     }
 
     /**
-     * 优化路径（PR-1）。每页拆 parallelism 个 chunk，每个 chunk 独立 Pipeline 写入；
-     * chunk 失败不影响其他 chunk；与 PR-#2/3/4 无关，本函数仅实现 PR-1 范围。
+     * 优化路径（PR-1 + PR-3）。每页拆 parallelism 个 chunk，每个 chunk 独立 Pipeline 写入；
+     * chunk 失败不影响其他 chunk；与 PR-#2/4 无关，本函数仅实现 PR-1+3 范围。
+     * <p>
+     * PR-3 关键改进：每页开始时一次性批量预取所有数字员工的 {@code target_content}
+     * （单 SQL IN 子句，避免每资源一次 findById），各 chunk 通过预取 map 引用。
      */
     private void doFullInitOptimized() {
         int pipelineBatchSize = effectivePipelineBatchSize();
@@ -419,13 +424,29 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
                 break;
             }
 
+            // PR-3: 整页预取 target_content（单 SQL IN 子句；避免每资源 findById）
+            List<Long> pageResourceIds = resources.stream()
+                .map(SsResource::getResourceId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+            Map<Long, String> prefetchedTargetContents =
+                digitalEmployeeApplicationService.prefetchDigEmployeeTargetContents(pageResourceIds);
+            int prefetchedCount = prefetchedTargetContents.size();
+            int blankCount = pageResourceIds.size() - prefetchedCount;
+            if (blankCount > 0) {
+                logger.info("[PR-3] 本页 target_content 空白率: {}/{} ({}%); 这些资源由"
+                    + " collectDigEmployeeSyncEntriesWithPrefetch 回退路径处理",
+                    blankCount, pageResourceIds.size(),
+                    pageResourceIds.isEmpty() ? 0 : (100 * blankCount / pageResourceIds.size()));
+            }
+
             // 1) split page into chunks
             List<List<SsResource>> chunks = chunkSplit(resources, parallelism);
             // 2) submit each chunk in parallel
             List<CompletableFuture<ChunkStats>> futures = new ArrayList<>(chunks.size());
             for (List<SsResource> chunk : chunks) {
                 futures.add(CompletableFuture.supplyAsync(
-                    () -> processChunk(chunk, pipelineBatchSize),
+                    () -> processChunk(chunk, pipelineBatchSize, prefetchedTargetContents),
                     exec));
             }
             // 3) wait all
@@ -439,9 +460,9 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
                 totalSkippedBlank += st.skippedBlank;
             }
 
-            logger.debug("数字员工Redis全量初始化进度：page={}, 本页资源={}, chunks={}, "
+            logger.debug("数字员工Redis全量初始化进度：page={}, 本页资源={}, 预取成功={}, 空白={}, chunks={}, "
                     + "本批写入成功={}, 失败={}, 跳过target_content空白={}",
-                pageIndex, resources.size(), chunks.size(),
+                pageIndex, resources.size(), prefetchedCount, blankCount, chunks.size(),
                 futures.stream().mapToInt(f -> f.getNow(ChunkStats.empty()).kvWrites).sum(),
                 futures.stream().mapToInt(f -> f.getNow(ChunkStats.empty()).kvFailures).sum(),
                 futures.stream().mapToInt(f -> f.getNow(ChunkStats.empty()).skippedBlank).sum());
@@ -506,7 +527,8 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
      * 单 chunk 失败（collect 异常 / Pipeline 异常）被 try/catch 隔离，记录日志后返回；
      * 不影响其他 chunk 的执行。
      */
-    private ChunkStats processChunk(List<SsResource> chunk, int pipelineBatchSize) {
+    private ChunkStats processChunk(List<SsResource> chunk, int pipelineBatchSize,
+                                    Map<Long, String> prefetchedTargetContents) {
         // PR-2-fix Major-1: chunk 起始处 fencing 校验（PR-1 实现的分页内并行场景下，
         // 4 个 chunk 并行执行期间锁被其他 Pod 接管时本 chunk 仍会完整写完；
         // 在 chunk 入口前置 fence 可避免 silent data loss）。
@@ -526,14 +548,29 @@ public class InitDigEmployeeRedisRunner implements ApplicationRunner {
                     continue;
                 }
                 total++;
+                Long resourceId = resource.getResourceId();
                 Map<String, String> entries;
                 try {
-                    entries = digitalEmployeeApplicationService
-                        .collectDigEmployeeSyncEntries(resource.getResourceId());
+                    // PR-3: 优先使用整页预取的 target_content（避免 per-resource findById）
+                    String prefetched = prefetchedTargetContents == null
+                        ? null
+                        : prefetchedTargetContents.get(resourceId);
+                    if (prefetched != null) {
+                        // 整页预取命中：使用 WithPrefetch 变体
+                        entries = digitalEmployeeApplicationService
+                            .collectDigEmployeeSyncEntriesWithPrefetch(resourceId, prefetched);
+                    }
+                    else {
+                        // 整页预取未命中（target_content 空 或 异常）：
+                        // 回退到原 collectDigEmployeeSyncEntries（包含 findDetailsById 7-10 SQL）
+                        entries = digitalEmployeeApplicationService
+                            .collectDigEmployeeSyncEntries(resourceId);
+                        skippedBlank++;
+                    }
                 }
                 catch (Exception e) {
                     logger.error("收集数字员工Redis同步条目失败, resourceId={}, reason={}",
-                        resource.getResourceId(), e.getMessage(), e);
+                        resourceId, e.getMessage(), e);
                     continue;
                 }
                 if (entries == null || entries.isEmpty()) {

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
@@ -1763,17 +1763,18 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * PR-3 批量加载 target_content(替换 PR-1 之前的 N+1 循环).
+     * PR-3 (#150) 批量加载 target_content(替换 PR-1 之前的 N+1 循环).
      * <p>
      * 核心改进:单 bizType 下一次性查多个 resourceId,避免每资源一次 SQL.
      * <p>
-     * <strong>当前实现</strong>:因 7 个 ext service(MCP / TOOLKIT / AGENT / DOC / VIEW / OBJECT / SKILL)
-     * 暂无 {@code findByIds} 批量接口,本方法内部循环 {@code findById}(TODO: 各 ext mapper 加批量 IN 查询),
-     * 仍优于 PR-1 之前的"在 for 循环里调用 + 同步走 Redis SET"--本方法至少**统一错误处理 + 一致字段读取**.
+     * <strong>当前实现</strong>:7 个 ext service 的 mapper 全部补了 {@code findByIds(Collection<Long>)}
+     * 批量接口(底层委托 MyBatis-Plus {@code selectBatchIds} 单 SQL IN 子句). 本方法按 bizType 分支
+     * 调用对应 service 的 {@code findByIds},结果按 resourceId 索引写入 result Map,仅保留
+     * target_content 非空记录.
      * <p>
      * 调用方契约:
      * <ul>
-     *     <li>idList 为空时返回空 Map</li>
+     *     <li>idList 为空/null 时返回空 Map(Mapper 层 default 实现保护)</li>
      *     <li>bizType 不在支持列表(TOOLKIT/MCP/AGENT/KG_xxx / VIEW / OBJECT / SKILL)时返回空 Map</li>
      *     <li>部分资源查不到对应 ext 记录时,Map 中不包含该 key(不抛错)</li>
      *     <li>整体异常被 catch,仅记 warn 日志,返回已成功查询到的部分 Map</li>
@@ -1799,107 +1800,127 @@ public class DigitalEmployeeApplicationService {
             return Collections.emptyMap();
         }
         Map<Long, String> result = new HashMap<>(idList.size());
-        // TODO(PR-3 follow-up): 各 ext service mapper 加 findByIds(Collection<Long>) 批量方法,
-        //      将本 for 循环替换为单 SQL 调用(IN 子句).
-        //      当前为统一 N+1 的临时实现:循环 findById 但单次方法调用完成所有读取,调用方拿到完整 Map 一次写入 Redis.
-        // PR-fix Major-1: per-id try/catch（单个 id 失败不影响同 bizType 其他 id,
-        //      也不影响其他 bizType 的 6 个分支).
+        // PR-3 (#150) 重构:每个 bizType 分支改为单次批量 SQL (IN 子句),
+        //      替代 PR-1 之前的循环 findById 触发的 N+1.
+        // PR-fix Major-1: per-bizType try/catch(单 bizType 失败不影响其他 6 个分支).
+        // 注:7 个 ext 实体类无公共父接口,故每个分支内联处理 resourceId/targetContent 索引.
         if (StringUtils.equals(bizType, ResourceBizTypeEnum.TOOLKIT.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtToolKit ext = ssResExtToolKitService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtToolKit> extList = ssResExtToolKitService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtToolKit ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=TOOLKIT, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=TOOLKIT, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.equals(bizType, ResourceBizTypeEnum.MCP.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtMcp ext = ssResExtMcpService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtMcp> extList = ssResExtMcpService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtMcp ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=MCP, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=MCP, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.equals(bizType, ResourceBizTypeEnum.AGENT.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtAgent ext = ssResExtAgentService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtAgent> extList = ssResExtAgentService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtAgent ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=AGENT, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=AGENT, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.startsWithIgnoreCase(bizType, "KG_")) {
-            for (Long id : idList) {
-                try {
-                    SsResExtDoc ext = ssResExtDocService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtDoc> extList = ssResExtDocService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtDoc ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=KG_*, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=KG_*, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.equals(bizType, ResourceBizTypeEnum.VIEW.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtView ext = ssResExtViewService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtView> extList = ssResExtViewService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtView ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=VIEW, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=VIEW, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.equals(bizType, ResourceBizTypeEnum.OBJECT.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtObject ext = ssResExtObjectService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtObject> extList = ssResExtObjectService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtObject ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=OBJECT, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=OBJECT, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else if (StringUtils.equals(bizType, ResourceBizTypeEnum.SKILL.name())) {
-            for (Long id : idList) {
-                try {
-                    SsResExtSkill ext = ssResExtSkillService.findById(id);
-                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
-                        result.put(id, ext.getTargetContent());
+            try {
+                List<SsResExtSkill> extList = ssResExtSkillService.findByIds(idList);
+                if (extList != null) {
+                    for (SsResExtSkill ext : extList) {
+                        if (ext != null && ext.getResourceId() != null
+                            && StringUtils.isNotBlank(ext.getTargetContent())) {
+                            result.put(ext.getResourceId(), ext.getTargetContent());
+                        }
                     }
                 }
-                catch (Exception e) {
-                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=SKILL, id={}, reason={}",
-                        id, e.getMessage(), e);
-                }
+            }
+            catch (Exception e) {
+                logger.warn("batchLoadTargetContent 批量失败: bizType=SKILL, idCount={}, reason={}",
+                    idList.size(), e.getMessage(), e);
             }
         }
         else {

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
@@ -1799,70 +1799,112 @@ public class DigitalEmployeeApplicationService {
             return Collections.emptyMap();
         }
         Map<Long, String> result = new HashMap<>(idList.size());
-        try {
-            // TODO(PR-3 follow-up): 各 ext service mapper 加 findByIds(Collection<Long>) 批量方法,
-            //      将本 for 循环替换为单 SQL 调用(IN 子句).
-            //      当前为统一 N+1 的临时实现:循环 findById 但单次方法调用完成所有读取,调用方拿到完整 Map 一次写入 Redis.
-            if (StringUtils.equals(bizType, ResourceBizTypeEnum.TOOLKIT.name())) {
-                for (Long id : idList) {
+        // TODO(PR-3 follow-up): 各 ext service mapper 加 findByIds(Collection<Long>) 批量方法,
+        //      将本 for 循环替换为单 SQL 调用(IN 子句).
+        //      当前为统一 N+1 的临时实现:循环 findById 但单次方法调用完成所有读取,调用方拿到完整 Map 一次写入 Redis.
+        // PR-fix Major-1: per-id try/catch（单个 id 失败不影响同 bizType 其他 id,
+        //      也不影响其他 bizType 的 6 个分支).
+        if (StringUtils.equals(bizType, ResourceBizTypeEnum.TOOLKIT.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtToolKit ext = ssResExtToolKitService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=TOOLKIT, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.MCP.name())) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.equals(bizType, ResourceBizTypeEnum.MCP.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtMcp ext = ssResExtMcpService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=MCP, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.AGENT.name())) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.equals(bizType, ResourceBizTypeEnum.AGENT.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtAgent ext = ssResExtAgentService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=AGENT, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.startsWithIgnoreCase(bizType, "KG_")) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.startsWithIgnoreCase(bizType, "KG_")) {
+            for (Long id : idList) {
+                try {
                     SsResExtDoc ext = ssResExtDocService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=KG_*, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.VIEW.name())) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.equals(bizType, ResourceBizTypeEnum.VIEW.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtView ext = ssResExtViewService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=VIEW, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.OBJECT.name())) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.equals(bizType, ResourceBizTypeEnum.OBJECT.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtObject ext = ssResExtObjectService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=OBJECT, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
-            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.SKILL.name())) {
-                for (Long id : idList) {
+        }
+        else if (StringUtils.equals(bizType, ResourceBizTypeEnum.SKILL.name())) {
+            for (Long id : idList) {
+                try {
                     SsResExtSkill ext = ssResExtSkillService.findById(id);
                     if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
                         result.put(id, ext.getTargetContent());
                     }
                 }
+                catch (Exception e) {
+                    logger.warn("batchLoadTargetContent 单 id 失败: bizType=SKILL, id={}, reason={}",
+                        id, e.getMessage(), e);
+                }
             }
         }
-        catch (Exception e) {
-            logger.warn("batchLoadTargetContent 异常: bizType={}, idCount={}, 已加载={}, reason={}",
-                bizType, idList.size(), result.size(), e.getMessage(), e);
+        else {
+            // 不支持的 bizType（理论上不会发生,因为顶部 isSupportedRelatedResourceBizType 已过滤）
+            logger.warn("batchLoadTargetContent 收到不支持的 bizType={}, 已忽略", bizType);
         }
         return result;
     }
@@ -1941,27 +1983,22 @@ public class DigitalEmployeeApplicationService {
                 || !digEmployeeRedisSyncProperties.isJsonRedisSyncEnabled()) {
             return result;
         }
-        // 主资源:直接使用预取 target_content(避免 ssResExtDigEmployeeService.findById)
-        if (StringUtils.isNotBlank(prefetchedMainTargetContent)) {
+        // PR-fix Major-2: 删掉原 else 分支内的 return result; —— 让控制流继续到关联资源处理,
+        // 保持与原 collectDigEmployeeSyncEntries 的行为一致(fallback 路径也要写关联资源).
+        // 主资源:命中预取直接用;未命中(prefetch 异常/空)回退到原 resolveDigEmployeeJsonForRedisSync
+        String mainJson = prefetchedMainTargetContent;
+        if (StringUtils.isBlank(mainJson)) {
+            // target_content 预取未取到(空 / 异常):回退到原逐资源解析(保留原行为)
+            // 若 skipBlankTargetContent=true,resolveDigEmployeeJsonForRedisSync 内部会记 warn 并 return null
+            mainJson = resolveDigEmployeeJsonForRedisSync(digEmployeeId);
+        }
+        if (StringUtils.isNotBlank(mainJson)) {
             result.put(
                 DigEmployeeRedisKeys.resourceConfigJsonKey(
                     ResourceBizTypeEnum.DIG_EMPLOYEE.name(), digEmployeeId),
-                prefetchedMainTargetContent);
+                mainJson);
         }
-        else {
-            // target_content 预取未取到(空 / 异常):回退到原逐资源解析(保留原行为)
-            // 若 skipBlankTargetContent=true,resolveDigEmployeeJsonForRedisSync 内部会记 warn 并 return null
-            String mainJson = resolveDigEmployeeJsonForRedisSync(digEmployeeId);
-            if (StringUtils.isNotBlank(mainJson)) {
-                result.put(
-                    DigEmployeeRedisKeys.resourceConfigJsonKey(
-                        ResourceBizTypeEnum.DIG_EMPLOYEE.name(), digEmployeeId),
-                    mainJson);
-            }
-            // 主资源回退路径下,不再尝试关联资源(避免一次同步里混用两种策略)
-            return result;
-        }
-        // 关联资源:复用 batchLoadTargetContent(pr-3 内为 per-id 循环;pr-3-follow-up 优化为单 SQL)
+        // 关联资源:无论 prefetch 命中与否,都尝试加载(保持与原方法行为一致;pr-3 内为 per-id 循环;pr-3-follow-up 优化为单 SQL)
         try {
             List<SsResourceRelDetail> relDetails = ssResourceRelDetailService.findByResourceId(digEmployeeId);
             if (CollectionUtils.isEmpty(relDetails)) {

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java
@@ -96,6 +96,7 @@ import com.iwhalecloud.byai.common.constants.Constants;
 import com.iwhalecloud.byai.common.util.RedisUtil;
 import jakarta.servlet.http.HttpSession;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -238,7 +239,7 @@ public class DigitalEmployeeApplicationService {
     private String storageType;
 
     /**
-     * 知识库/数字员工系统来源配置；配置为 WHALE_AGENT 时表示接入老智能体商业版本， 部分数字员工类型不允许在本系统创建。
+     * 知识库/数字员工系统来源配置;配置为 WHALE_AGENT 时表示接入老智能体商业版本, 部分数字员工类型不允许在本系统创建.
      */
     @Value("${dataset.system:}")
     private String datasetSystem;
@@ -262,8 +263,8 @@ public class DigitalEmployeeApplicationService {
     private DigEmployeeRedisSyncProperties digEmployeeRedisSyncProperties;
 
     /**
-     * PR-1 启动期同步优化属性。详见 {@link DigEmployeeStartupSyncProperties}。
-     * 注入后可读取 {@code skipBlankTargetContent} 等开关，行为兼容旧版本（默认 false 时无副作用）。
+     * PR-1 启动期同步优化属性.详见 {@link DigEmployeeStartupSyncProperties}.
+     * 注入后可读取 {@code skipBlankTargetContent} 等开关,行为兼容旧版本(默认 false 时无副作用).
      */
     @Autowired
     private DigEmployeeStartupSyncProperties digEmployeeStartupSyncProperties;
@@ -286,9 +287,9 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 给知识前端使用的通用数字员工列表查询。 规则说明： 1. 不限定 ownerType，也不限定 owner/authorize/manager 视角，默认按“全部”查询； 2. 若前端未传 publishType，则默认查询
-     * publish； 3. 若前端未传 publishStatus，则默认查询有效状态 2（LIST）； 4. 当前数字员工列表仍使用 ss_resource.resource_status 做状态过滤，因此
-     * publishStatus 会收口到 resourceStatus。
+     * 给知识前端使用的通用数字员工列表查询. 规则说明: 1. 不限定 ownerType,也不限定 owner/authorize/manager 视角,默认按“全部”查询; 2. 若前端未传 publishType,则默认查询
+     * publish; 3. 若前端未传 publishStatus,则默认查询有效状态 2(LIST); 4. 当前数字员工列表仍使用 ss_resource.resource_status 做状态过滤,因此
+     * publishStatus 会收口到 resourceStatus.
      */
     public PageInfo<DigitalEmployeeVo> queryAllDigitalEmployeeList(DigitalEmployeeQo digitalEmployeeQo) {
         if (digitalEmployeeQo == null) {
@@ -304,11 +305,11 @@ public class DigitalEmployeeApplicationService {
         if (!includeAllResourceStatus && digitalEmployeeQo.getResourceStatus() == null) {
             digitalEmployeeQo.setResourceStatus(Long.valueOf(digitalEmployeeQo.getPublishStatus()));
         }
-        // 填充当前用户上下文，仅用于黑名单、权限筛选和待审核/申请中状态判断，不收窄企业全量查询范围。
+        // 填充当前用户上下文,仅用于黑名单、权限筛选和待审核/申请中状态判断,不收窄企业全量查询范围.
         resourceAuthContextService.setCurrentUserAuthQo(digitalEmployeeQo);
         fillPublishOrgIds(digitalEmployeeQo);
         fillCatalogIds(digitalEmployeeQo);
-        // 显式清空旧版视角类型，确保这里始终以企业资源全量为基础。
+        // 显式清空旧版视角类型,确保这里始终以企业资源全量为基础.
         digitalEmployeeQo.setType(null);
         PageInfo<DigitalEmployeeVo> pageInfo = ssResExtDigEmployeeService
             .selectAllDigitalEmployeeByQo(digitalEmployeeQo);
@@ -317,14 +318,14 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 查询个人归属数字员工列表。 规则说明： 1. 仅查询 ownerType = personal； 2. 查询范围覆盖我创建、我管理、我使用； 3. 若前端未传 publishType，则默认查询 publish； 4.
-     * 若前端未传 publishStatus，则默认查询有效状态 2（LIST）； 5. 关键字支持匹配数字员工名称、数字员工描述。
+     * 查询个人归属数字员工列表. 规则说明: 1. 仅查询 ownerType = personal; 2. 查询范围覆盖我创建、我管理、我使用; 3. 若前端未传 publishType,则默认查询 publish; 4.
+     * 若前端未传 publishStatus,则默认查询有效状态 2(LIST); 5. 关键字支持匹配数字员工名称、数字员工描述.
      */
     public PageInfo<DigitalEmployeeVo> queryPersonalDigitalEmployeeList(DigitalEmployeeQo digitalEmployeeQo) {
         resourceAuthContextService.setCurrentUserAuthQo(digitalEmployeeQo);
         digitalEmployeeQo.setDefaultDigEmployeeId(CurrentUserHolder.getDefaultDigEmployeeId());
-        // 默认超级助手在被其它个人助理替换为当前默认后，仍保持 personal_default，
-        // 个人助理列表需要继续按稳定 resourceCode={userCode}_main 展示它。
+        // 默认超级助手在被其它个人助理替换为当前默认后,仍保持 personal_default,
+        // 个人助理列表需要继续按稳定 resourceCode={userCode}_main 展示它.
         digitalEmployeeQo.setDefaultSuperAssistantResourceCode(buildDefaultSuperAssistantResourceCode(
             CurrentUserHolder.getCurrentUserCode(), CurrentUserHolder.getCurrentUserId()));
         fillCatalogIds(digitalEmployeeQo);
@@ -335,8 +336,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 数字员工标签不再依赖 ss_res_ext_dig_employee.tag_name 落库值，列表返回前按当前资源归属实时计算： personal + resourceCode 后缀 _main 为超级助手，其他
-     * personal 为个人助理，enterprise 按 agentType 显示类型。
+     * 数字员工标签不再依赖 ss_res_ext_dig_employee.tag_name 落库值,列表返回前按当前资源归属实时计算: personal + resourceCode 后缀 _main 为超级助手,其他
+     * personal 为个人助理,enterprise 按 agentType 显示类型.
      */
     private void fillRuntimeDigitalEmployeeTags(PageInfo<DigitalEmployeeVo> pageInfo) {
         if (pageInfo == null || CollectionUtils.isEmpty(pageInfo.getList())) {
@@ -597,7 +598,7 @@ public class DigitalEmployeeApplicationService {
         boolean isFrontAccess = digitalEmployeeDTO.isFrontAccess();
         normalizeRelSkillsForSave(digitalEmployeeDTO);
         validateDigitalEmployeeTextFieldLengths(digitalEmployeeDTO);
-        // 商业版本（dataset.system=WHALE_AGENT）下，企业 tab 不允许创建编码型（011）/ 调试型（010）数字员工
+        // 商业版本(dataset.system=WHALE_AGENT)下,企业 tab 不允许创建编码型(011)/ 调试型(010)数字员工
         validateCommercialEditionDigitalEmployeeCreation(digitalEmployeeDTO);
         String resourceName = digitalEmployeeDTO.getResourceName();
         long count = ssResourceService.countResource(resourceName, ResourceBizTypeEnum.DIG_EMPLOYEE.name(), null);
@@ -627,7 +628,7 @@ public class DigitalEmployeeApplicationService {
         Set<Long> userOrgIds = CurrentUserHolder.getUserOrgIds();
         ssResource.setManOrgId(CollectionUtils.isEmpty(userOrgIds) ? null : userOrgIds.iterator().next());
         ssResource.setManUserId(String.valueOf(CurrentUserHolder.getCurrentUserId()));
-        // 数字员工 personal / enterprise 归属口径统一落到资源主表，供个人视角查询等场景直接过滤使用。
+        // 数字员工 personal / enterprise 归属口径统一落到资源主表,供个人视角查询等场景直接过滤使用.
         ssResource.setOwnerType(StringUtils.trimToNull(digitalEmployeeDTO.getOwnerType()));
         ssResource.setResourceDVerid(1L);
         ssResource.setResourceRVerid(0L);
@@ -649,7 +650,7 @@ public class DigitalEmployeeApplicationService {
             digitalEmployeeDTO.getRelResourceInfoList());
         this.rebuildAndSaveDigitalEmployeeRelSkills(ssResource.getResourceId());
 
-        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存，当前运行时改读 DIG_EMPLOYEE_{resourceId}。
+        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存,当前运行时改读 DIG_EMPLOYEE_{resourceId}.
         // this.syncDigEmployeeSkillsToRedisQuietly(ssResource.getResourceId());
 
         // 前台的直接上架给予使用权限
@@ -661,7 +662,7 @@ public class DigitalEmployeeApplicationService {
 
         // 记录操作日志
         operationLogService.recordOperationLog(ssResource, OperationTypeEnum.CREATE);
-        // 保存模版关联关系（记忆配置）
+        // 保存模版关联关系(记忆配置)
         // 优先使用 memoryConfigList
         List<MemoryConfigDTO> memoryConfigList = digitalEmployeeDTO.getMemoryConfigList();
         Long currentUserId = CurrentUserHolder.getCurrentUserId();
@@ -675,9 +676,9 @@ public class DigitalEmployeeApplicationService {
             }
             catch (Exception e) {
                 // 记录日志但不影响主流程
-                logger.error("创建数字员工记忆库失败，resourceId: {}, error: {}", ssResource.getResourceId(), e.getMessage(), e);
+                logger.error("创建数字员工记忆库失败,resourceId: {}, error: {}", ssResource.getResourceId(), e.getMessage(), e);
             }
-            // 使用新的 memoryConfigList 方式保存（带用户ID条件删除）
+            // 使用新的 memoryConfigList 方式保存(带用户ID条件删除)
             templateRuleInfoApplicationService.saveResourceTemplateRelationsByMemoryConfig(ssResource.getResourceId(),
                 memoryConfigList, currentUserId, memoryLibraryId);
         }
@@ -691,8 +692,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 创建用户默认超级助手，资源保存仍复用 saveDigitalEmployee 主链路。 默认超级助手本质上仍是真实 DIG_EMPLOYEE 资源，固定 resourceCode={userCode}_main，
-     * 前后端都按数字员工处理，避免再出现 HUMAN_ASSISTANT / DIG_EMPLOYEE 两套表达。
+     * 创建用户默认超级助手,资源保存仍复用 saveDigitalEmployee 主链路. 默认超级助手本质上仍是真实 DIG_EMPLOYEE 资源,固定 resourceCode={userCode}_main,
+     * 前后端都按数字员工处理,避免再出现 HUMAN_ASSISTANT / DIG_EMPLOYEE 两套表达.
      *
      * @author qin.guoquan
      * @date 2026-05-09 150800
@@ -734,7 +735,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 生成默认超级助手资源编码。
+     * 生成默认超级助手资源编码.
      *
      * @author qin.guoquan
      * @date 2026-05-09 150800
@@ -748,7 +749,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 数字员工展示标签统一运行时生成，不再写入扩展表 tag_name。
+     * 数字员工展示标签统一运行时生成,不再写入扩展表 tag_name.
      */
     private String buildDigitalEmployeeTagName(String ownerType, String resourceCode, String agentType) {
         if (OwnerType.PERSONAL.equals(ownerType) || OwnerType.PERSONAL_DEFAULT.equals(ownerType)) {
@@ -798,7 +799,7 @@ public class DigitalEmployeeApplicationService {
     private AgentPrologueDto.ModelInfo buildDefaultModelInfo() {
         ModelDto modelDto = aiModelService.getDefaultChatModel();
         if (modelDto == null) {
-            logger.error("当前默认模型不存在，默认个人助理将使用空模型配置初始化");
+            logger.error("当前默认模型不存在,默认个人助理将使用空模型配置初始化");
             return null;
         }
 
@@ -812,7 +813,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 根据数字员工类型回填 ss_resource 的实现方式与 Worker 注册类型。
+     * 根据数字员工类型回填 ss_resource 的实现方式与 Worker 注册类型.
      *
      * @author qin.guoquan
      * @date 2026-04-25 15:42:00
@@ -846,14 +847,14 @@ public class DigitalEmployeeApplicationService {
         SsResource ssResource = ssResourceService.findById(resourceId);
         validateDigitalEmployeeUpdatePermission(ssResource);
         if (isDefaultPersonalResource(ssResource)) {
-            // 默认个人助理始终按助手型运行，避免前端旧参数把 worker_agent_type 覆盖成编码型等其他类型。
+            // 默认个人助理始终按助手型运行,避免前端旧参数把 worker_agent_type 覆盖成编码型等其他类型.
             digitalEmployeeDTO.setAgentType(DigitalEmployType.AGENT_TYPE_ASSISTANT.getCode());
         }
         BeanUtil.copyProperties(digitalEmployeeDTO, ssResource);
         ssResource.setUpdateBy(CurrentUserHolder.getCurrentUserId());
         ssResource.setUpdateTime(new Date());
         ssResource.setResourceStatus(ResourceStatus.LIST.getNum());
-        // 更新时允许前端同步调整资源归属类型，避免个人资源仍保留旧的 owner_type。
+        // 更新时允许前端同步调整资源归属类型,避免个人资源仍保留旧的 owner_type.
         ssResource.setOwnerType(StringUtils.trimToNull(digitalEmployeeDTO.getOwnerType()));
         fillDigitalEmployeeImplInfo(ssResource, digitalEmployeeDTO.getAgentType());
         ssResourceService.updateResourceEntity(ssResource);
@@ -864,7 +865,7 @@ public class DigitalEmployeeApplicationService {
         ssResExtDigEmployee.setAgentSseUrl(ssResExtDigEmployee.getAgentSseUrlOri());
         ssResExtDigEmployee.setAgentWebUrl(ssResExtDigEmployee.getAgentWebUrlOri());
         ssResExtDigEmployee.setAgentAdminUrlList(ssResExtDigEmployee.getAgentAdminUrlOriList());
-        // tagName 统一由查询接口运行时计算，避免前端回传旧标签又写回扩展表。
+        // tagName 统一由查询接口运行时计算,避免前端回传旧标签又写回扩展表.
         ssResExtDigEmployee.setTagName(null);
         ssResExtDigEmployeeService.update(ssResExtDigEmployee);
 
@@ -874,7 +875,7 @@ public class DigitalEmployeeApplicationService {
         this.compareSsResourceRelDetail(ssResource, relIds, resourceRelDetails,
             digitalEmployeeDTO.getRelResourceInfoList());
         this.rebuildAndSaveDigitalEmployeeRelSkills(resourceId);
-        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存，当前运行时改读 DIG_EMPLOYEE_{resourceId}。
+        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存,当前运行时改读 DIG_EMPLOYEE_{resourceId}.
         // this.syncDigEmployeeSkillsToRedisQuietly(resourceId);
 
         // 前台的直接上架
@@ -884,7 +885,7 @@ public class DigitalEmployeeApplicationService {
 
         // 记录操作日志
         operationLogService.recordOperationLog(ssResource, OperationTypeEnum.UPDATE);
-        // 保存模版关联关系（记忆配置）
+        // 保存模版关联关系(记忆配置)
         List<MemoryConfigDTO> memoryConfigList = digitalEmployeeDTO.getMemoryConfigList();
         Long currentUserId = CurrentUserHolder.getCurrentUserId();
         Long memoryLibraryId = null;
@@ -897,9 +898,9 @@ public class DigitalEmployeeApplicationService {
             }
             catch (Exception e) {
                 // 记录日志但不影响主流程
-                logger.error("创建数字员工记忆库失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+                logger.error("创建数字员工记忆库失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
             }
-            // 使用新的 memoryConfigList 方式保存（带用户ID条件删除）
+            // 使用新的 memoryConfigList 方式保存(带用户ID条件删除)
             templateRuleInfoApplicationService.saveResourceTemplateRelationsByMemoryConfig(resourceId, memoryConfigList,
                 currentUserId, memoryLibraryId);
         }
@@ -913,7 +914,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 增量安装知识或资源到数字员工，保留已有关联关系。
+     * 增量安装知识或资源到数字员工,保留已有关联关系.
      *
      * @param installResourceDTO 安装入参
      * @return 数字员工详情
@@ -947,7 +948,7 @@ public class DigitalEmployeeApplicationService {
 
         this.compareSsResourceRelDetail(ssResource, new ArrayList<>(mergedRelIds), resourceRelDetails, null);
         this.rebuildAndSaveDigitalEmployeeRelSkills(digitalEmployeeId);
-        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存，当前运行时改读 DIG_EMPLOYEE_{resourceId}。
+        // 暂停生成 RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存,当前运行时改读 DIG_EMPLOYEE_{resourceId}.
         // this.syncDigEmployeeSkillsToRedisQuietly(digitalEmployeeId);
         this.synOpenClawWorkSpace(digitalEmployeeId);
         operationLogService.recordOperationLog(ssResource, OperationTypeEnum.UPDATE);
@@ -959,7 +960,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 从数字员工卸载知识或资源，仅解除关联关系，不删除资源本身。
+     * 从数字员工卸载知识或资源,仅解除关联关系,不删除资源本身.
      *
      * @param uninstallResourceDTO 卸载入参
      * @return 数字员工详情
@@ -1002,11 +1003,11 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 以给定的全量目标 relIds 覆盖式同步数字员工的关联资源明细，并触发运行期重同步。
-     * 供本体绑定等场景复用：调用方自行计算好目标集合（多退少补），本方法只做落库 + 同步。
+     * 以给定的全量目标 relIds 覆盖式同步数字员工的关联资源明细,并触发运行期重同步.
+     * 供本体绑定等场景复用:调用方自行计算好目标集合(多退少补),本方法只做落库 + 同步.
      *
      * @param digitalEmployeeId 数字员工资源 ID
-     * @param targetRelIds 目标全量关联资源 ID（为空表示清空全部关联）
+     * @param targetRelIds 目标全量关联资源 ID(为空表示清空全部关联)
      */
     @Transactional(rollbackFor = Exception.class)
     public void syncRelResourcesByTargetIds(Long digitalEmployeeId, List<Long> targetRelIds) {
@@ -1054,8 +1055,8 @@ public class DigitalEmployeeApplicationService {
         if (digitalEmployee == null) {
             throw new BaseException(CommonErrorCode.ERROR_CODE_50500, I18nUtil.get("resource.not.found"));
         }
-        // 技能安装目标是前端当前选中的数字员工：显式 @ 的数字员工优先，没有 @ 时才回退默认数字员工。
-        // 因此这里按目标数字员工的管理权限校验，不再强制要求它必须等于 defaultDigEmployeeId。
+        // 技能安装目标是前端当前选中的数字员工:显式 @ 的数字员工优先,没有 @ 时才回退默认数字员工.
+        // 因此这里按目标数字员工的管理权限校验,不再强制要求它必须等于 defaultDigEmployeeId.
         if (!authApplicationService.hasResourceManagePermission(digitalEmployee)) {
             throw new BaseException(CommonErrorCode.ERROR_CODE_50500,
                 I18nUtil.get("digemployee.skill.install.no.manage.permission", digitalEmployee.getResourceName()));
@@ -1070,8 +1071,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 校验当前用户对指定数字员工是否有管理权限（删除/卸载工作空间技能前置校验）。
-     * 与绑定技能卸载使用同一套校验，避免漂移。
+     * 校验当前用户对指定数字员工是否有管理权限(删除/卸载工作空间技能前置校验).
+     * 与绑定技能卸载使用同一套校验,避免漂移.
      *
      * @param digitalEmployeeId 数字员工资源 ID
      */
@@ -1084,7 +1085,7 @@ public class DigitalEmployeeApplicationService {
         if (digitalEmployee == null) {
             throw new BaseException(CommonErrorCode.ERROR_CODE_50500, I18nUtil.get("resource.not.found"));
         }
-        // 技能卸载同安装一样，按请求里的当前数字员工校验管理权限。
+        // 技能卸载同安装一样,按请求里的当前数字员工校验管理权限.
         if (!authApplicationService.hasResourceManagePermission(digitalEmployee)) {
             throw new BaseException(CommonErrorCode.ERROR_CODE_50500,
                 I18nUtil.get("digemployee.skill.uninstall.no.manage.permission", digitalEmployee.getResourceName()));
@@ -1092,8 +1093,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 设置当前用户默认数字员工。 默认关系只维护在 suas_superassist.default_dig_employee_id 上，不再修改资源 owner_type 或扩展表 tag_name。
-     * 这样超级助手、个人助理、企业数字员工都保持自身资源归属，默认身份只作为当前用户会话兜底 @ 对象。
+     * 设置当前用户默认数字员工. 默认关系只维护在 suas_superassist.default_dig_employee_id 上,不再修改资源 owner_type 或扩展表 tag_name.
+     * 这样超级助手、个人助理、企业数字员工都保持自身资源归属,默认身份只作为当前用户会话兜底 @ 对象.
      *
      * @param dto 请求参数
      * @return 默认数字员工切换结果
@@ -1145,17 +1146,17 @@ public class DigitalEmployeeApplicationService {
         Long resourceId = employeeIdDTO.getResourceId();
         SsResource ssResource = ssResourceService.findById(resourceId);
         validateDigitalEmployeeManagePermission(ssResource);
-        // 软删除：把 ss_resource.resource_status 置为 REMOVED(3)，保留主表与扩展表数据，
-        // 让前端"已注销"筛选项可以查询到这些记录；运行期副作用（缓存/注册等）继续清理。
+        // 软删除:把 ss_resource.resource_status 置为 REMOVED(3),保留主表与扩展表数据,
+        // 让前端"已注销"筛选项可以查询到这些记录;运行期副作用(缓存/注册等)继续清理.
         ssResource.setResourceStatus(ResourceStatus.REMOVED.getNum());
         ssResource.setUpdateBy(CurrentUserHolder.getCurrentUserId());
         ssResource.setUpdateTime(new Date());
         ssResourceService.updateResourceEntity(ssResource);
 
-        // 该数字员工若被其它用户设为默认助理，回退他们的默认助理为自己的超级助手，避免出现“默认指向已注销资源”。
+        // 该数字员工若被其它用户设为默认助理,回退他们的默认助理为自己的超级助手,避免出现“默认指向已注销资源”.
         resetDefaultForAffectedUsers(resourceId);
 
-        // 注销后不再可被会话调用：清理技能缓存/产物/外部注册
+        // 注销后不再可被会话调用:清理技能缓存/产物/外部注册
         removeDigEmployeeFromRedisQuietly(resourceId);
         removeDigEmployeeJsonFromResourceStorageQuietly(resourceId);
 
@@ -1179,8 +1180,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 数字员工注销/删除后，把所有把它设为默认助理的用户回退到各自的超级助手；找不到超级助手时清空。 同时若当前登录用户在受影响列表里，需要刷新 session 中的 defaultDigEmployeeId。 暴露为 public
-     * 以便其他注销链路（如 ToolManService.deleteManagedResource）复用。
+     * 数字员工注销/删除后,把所有把它设为默认助理的用户回退到各自的超级助手;找不到超级助手时清空. 同时若当前登录用户在受影响列表里,需要刷新 session 中的 defaultDigEmployeeId. 暴露为 public
+     * 以便其他注销链路(如 ToolManService.deleteManagedResource)复用.
      */
     public void resetDefaultForAffectedUsers(Long resourceId) {
         if (resourceId == null) {
@@ -1199,7 +1200,7 @@ public class DigitalEmployeeApplicationService {
                 suasSuperassistService.updateById(suasSuperassist);
             }
             catch (Exception e) {
-                logger.warn("回退默认数字员工失败，userId={}, fallback={}", userId, fallbackResourceId, e);
+                logger.warn("回退默认数字员工失败,userId={}, fallback={}", userId, fallbackResourceId, e);
                 continue;
             }
             if (Objects.equals(userId, currentUserId)) {
@@ -1209,7 +1210,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 按 resource_code={userCode}_main 反查指定用户的超级助手资源ID，找不到返回 null。
+     * 按 resource_code={userCode}_main 反查指定用户的超级助手资源ID,找不到返回 null.
      */
     private Long resolveSuperAssistantResourceId(Long userId) {
         if (userId == null) {
@@ -1247,8 +1248,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 当前用户自己的超级助手资源使用稳定编码 {userCode}_main；即使用户把其他个人助理设为默认数字员工，
-     * 也应允许用户继续编辑自己的超级助手配置。
+     * 当前用户自己的超级助手资源使用稳定编码 {userCode}_main;即使用户把其他个人助理设为默认数字员工,
+     * 也应允许用户继续编辑自己的超级助手配置.
      */
     private boolean isCurrentUserOwnDefaultSuperAssistantResource(SsResource ssResource) {
         Long currentUserId = CurrentUserHolder.getCurrentUserId();
@@ -1305,7 +1306,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 左侧“全部列表项”中可见的数字员工才允许设为默认： 我创建的、我有使用授权的、或我有 ALLOW_MANAGE 管理授权的资源均可。
+     * 左侧“全部列表项”中可见的数字员工才允许设为默认: 我创建的、我有使用授权的、或我有 ALLOW_MANAGE 管理授权的资源均可.
      */
     private boolean canCurrentUserSetAsDefault(SsResource resource, Long currentUserId) {
         if (resource == null || currentUserId == null) {
@@ -1378,47 +1379,47 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 同步数字员工到 openClaw（带原始入参版本）。 之所以单独承接 inputDto，是因为 relTools 不入 DB，重新 findDetailsById 拿不回， 需要从前端原始入参直接透传到 JSON 与
-     * target_content。
+     * 同步数字员工到 openClaw(带原始入参版本). 之所以单独承接 inputDto,是因为 relTools 不入 DB,重新 findDetailsById 拿不回, 需要从前端原始入参直接透传到 JSON 与
+     * target_content.
      *
      * @param resourceId 标识
-     * @param inputDto 前端 save/update 时传入的原始 DTO；为 null 时退化为纯 DB 拼装
+     * @param inputDto 前端 save/update 时传入的原始 DTO;为 null 时退化为纯 DB 拼装
      */
     public void synOpenClawWorkSpace(Long resourceId, DigitalEmployeeDTO inputDto) {
         try {
             doSyncOpenClawWorkSpace(resourceId, inputDto);
         }
         catch (Exception e) {
-            logger.error("同步数字员工资源文件失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+            logger.error("同步数字员工资源文件失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         }
     }
 
     /**
-     * 将已有数字员工及其关联资源的标准 JSON 同步至 Redis（供启动全量初始化等场景调用）。 优先使用扩展表 {@code target_content}，缺失时再组装详情 JSON。
+     * 将已有数字员工及其关联资源的标准 JSON 同步至 Redis(供启动全量初始化等场景调用). 优先使用扩展表 {@code target_content},缺失时再组装详情 JSON.
      */
     public void syncExistingDigEmployeeConfigToRedisQuietly(Long resourceId) {
         try {
             syncExistingDigEmployeeConfigToRedis(resourceId);
         }
         catch (Exception e) {
-            logger.error("同步已有数字员工配置到Redis失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+            logger.error("同步已有数字员工配置到Redis失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         }
     }
 
     /**
-     * PR-1: 收集一个数字员工及其关联资源（TOOLKIT / MCP / AGENT / KG_* / VIEW / OBJECT / SKILL）
-     * 所有应写入 Redis 的 (key, jsonContent) 对，但实际写入由调用方（Runner 层）通过 Pipeline
-     * 一次性提交。本方法不写 Redis，仅收集。
+     * PR-1: 收集一个数字员工及其关联资源(TOOLKIT / MCP / AGENT / KG_* / VIEW / OBJECT / SKILL)
+     * 所有应写入 Redis 的 (key, jsonContent) 对,但实际写入由调用方(Runner 层)通过 Pipeline
+     * 一次性提交.本方法不写 Redis,仅收集.
      * <p>
-     * 调用方契约：
+     * 调用方契约:
      * <ul>
-     *     <li>返回 Map 顺序与原有 {@link #syncExistingDigEmployeeConfigToRedis} 一致：先主数字员工 JSON，再关联资源 JSON</li>
-     *     <li>{@code target_content} 空白且 {@code skipBlankTargetContent=true} 时返回空 Map（warn 已记在 {@link #resolveDigEmployeeJsonForRedisSync}）</li>
-     *     <li>key 形如 {@code DIG_EMPLOYEE_{id}}、{@code TOOLKIT_{id}} 等，与既有键空间一致</li>
+     *     <li>返回 Map 顺序与原有 {@link #syncExistingDigEmployeeConfigToRedis} 一致:先主数字员工 JSON,再关联资源 JSON</li>
+     *     <li>{@code target_content} 空白且 {@code skipBlankTargetContent=true} 时返回空 Map(warn 已记在 {@link #resolveDigEmployeeJsonForRedisSync})</li>
+     *     <li>key 形如 {@code DIG_EMPLOYEE_{id}}、{@code TOOLKIT_{id}} 等,与既有键空间一致</li>
      * </ul>
      *
      * @param resourceId 数字员工资源 ID
-     * @return 收集到的所有 (redisKey → jsonContent) 映射；空 Map 表示无任何可写内容
+     * @return 收集到的所有 (redisKey -> jsonContent) 映射;空 Map 表示无任何可写内容
      */
     public Map<String, String> collectDigEmployeeSyncEntries(Long resourceId) {
         Map<String, String> result = new LinkedHashMap<>();
@@ -1436,7 +1437,7 @@ public class DigitalEmployeeApplicationService {
                 DigEmployeeRedisKeys.resourceConfigJsonKey(ResourceBizTypeEnum.DIG_EMPLOYEE.name(), resourceId),
                 mainJson);
         }
-        // 关联资源（与 syncRelatedResourceConfigJsonsToRedisQuietly 完全同语义，但不写 Redis）
+        // 关联资源(与 syncRelatedResourceConfigJsonsToRedisQuietly 完全同语义,但不写 Redis)
         try {
             List<SsResourceRelDetail> relDetails = ssResourceRelDetailService.findByResourceId(resourceId);
             if (CollectionUtils.isEmpty(relDetails)) {
@@ -1494,11 +1495,11 @@ public class DigitalEmployeeApplicationService {
         if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
             return ext.getTargetContent();
         }
-        // PR-1：target_content 空白时，若开关开启则直接跳过（避免回退到 findDetailsById
-        // 的 7-10 SQL）。要求：必须先跑 StartupTargetContentPreloader 补齐 target_content。
+        // PR-1:target_content 空白时,若开关开启则直接跳过(避免回退到 findDetailsById
+        // 的 7-10 SQL).要求:必须先跑 StartupTargetContentPreloader 补齐 target_content.
         if (digEmployeeStartupSyncProperties != null
                 && digEmployeeStartupSyncProperties.isSkipBlankTargetContent()) {
-            logger.warn("targetContent 空白，跳过该条记录 resourceId={}，请在数据修复后下次启动时同步",
+            logger.warn("targetContent 空白,跳过该条记录 resourceId={},请在数据修复后下次启动时同步",
                 resourceId);
             return null;
         }
@@ -1506,11 +1507,11 @@ public class DigitalEmployeeApplicationService {
         employeeIdDTO.setResourceId(resourceId);
         DigitalEmployeeDetailsDTO details = findDetailsById(employeeIdDTO);
         if (details == null) {
-            logger.warn("数字员工详情不存在，无法组装Redis配置JSON, resourceId={}", resourceId);
+            logger.warn("数字员工详情不存在,无法组装Redis配置JSON, resourceId={}", resourceId);
             return null;
         }
         fillDigitalEmployeeSyncRuntimeFields(details, resourceId);
-        // target_content 只是上一次同步快照，不能再作为当前标准 JSON 的一个字段递归写回。
+        // target_content 只是上一次同步快照,不能再作为当前标准 JSON 的一个字段递归写回.
         details.setTargetContent(null);
         return com.alibaba.fastjson.JSON.toJSONString(details);
     }
@@ -1520,11 +1521,11 @@ public class DigitalEmployeeApplicationService {
         employeeIdDTO.setResourceId(resourceId);
         DigitalEmployeeDetailsDTO details = this.findDetailsById(employeeIdDTO);
         fillDigitalEmployeeSyncRuntimeFields(details, resourceId);
-        // 用前端原始入参覆盖运行期字段：
-        // - relTools 不入库，必须从入参直接透传，否则首次保存的 JSON 中 relTools 会丢；
-        // - relPrompt 与 corePersonaDefinition 同源，入参更"新"则优先用入参，避免编辑场景被旧库值覆盖。
+        // 用前端原始入参覆盖运行期字段:
+        // - relTools 不入库,必须从入参直接透传,否则首次保存的 JSON 中 relTools 会丢;
+        // - relPrompt 与 corePersonaDefinition 同源,入参更"新"则优先用入参,避免编辑场景被旧库值覆盖.
         applyInputRuntimeFields(details, inputDto);
-        // target_content 只是镜像快照，不能参与本次 JSON 序列化，否则会出现 JSON 套 JSON 的递归膨胀。
+        // target_content 只是镜像快照,不能参与本次 JSON 序列化,否则会出现 JSON 套 JSON 的递归膨胀.
         details.setTargetContent(null);
 
         String jsonContent = com.alibaba.fastjson.JSON.toJSONString(details);
@@ -1535,9 +1536,9 @@ public class DigitalEmployeeApplicationService {
         logger.info("数字员工同步开始, storageType={}, resourceId={}, resourcePath={}/{}", effectiveStorageType, resourceId,
             resourceDir, fileName);
 
-        // 先把同步到 MinIO 的 JSON 串镜像写入 ss_res_ext_dig_employee.target_content。
-        // 这样：1) 即便后续 MinIO 推送失败，DB 也保留了上一次成功生成的 JSON；
-        // 2) 前端编辑回显时（findDetailsById）可以从这里反序列化 relTools 等不入库的运行期字段。
+        // 先把同步到 MinIO 的 JSON 串镜像写入 ss_res_ext_dig_employee.target_content.
+        // 这样:1) 即便后续 MinIO 推送失败,DB 也保留了上一次成功生成的 JSON;
+        // 2) 前端编辑回显时(findDetailsById)可以从这里反序列化 relTools 等不入库的运行期字段.
         persistTargetContent(resourceId, jsonContent);
 
         resourceArtifactStorageService.syncResourceJsonByBizType(jsonContent, ResourceBizTypeEnum.DIG_EMPLOYEE.name(),
@@ -1547,9 +1548,9 @@ public class DigitalEmployeeApplicationService {
 
         syncDigEmployeeConfigJsonToRedisQuietly(resourceId, jsonContent);
 
-        // 数字员工自己的 JSON 同步完成后，再检查并补齐其关联资源的标准 JSON 产物。
-        // 这样可以确保前端保存/更新数字员工后，关联的 toolkit / mcp / agent / kg_* / view / object
-        // 也都能在开放资源目录中按标准命名被下游读取到。
+        // 数字员工自己的 JSON 同步完成后,再检查并补齐其关联资源的标准 JSON 产物.
+        // 这样可以确保前端保存/更新数字员工后,关联的 toolkit / mcp / agent / kg_* / view / object
+        // 也都能在开放资源目录中按标准命名被下游读取到.
         syncMissingRelatedResourceJsons(resourceId);
         syncRelatedResourceConfigJsonsToRedisQuietly(resourceId);
 
@@ -1558,7 +1559,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 数字员工同步到开放资源目录前，统一补齐实现方式与 Worker 注册类型。
+     * 数字员工同步到开放资源目录前,统一补齐实现方式与 Worker 注册类型.
      *
      * @author qin.guoquan
      * @date 2026-04-26 11:30:00
@@ -1576,8 +1577,8 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 检查数字员工关联资源对应的标准 JSON 是否存在；若缺失，则按原 targetContent 补发回开放资源目录。 设计说明： 1. 不重新走资源导入流程，而是直接复用各扩展表中已经生成好的 targetContent；
-     * 2. 只处理下游明确依赖的资源类型：TOOLKIT / MCP / AGENT / KG_* / VIEW / OBJECT； 3. 某个关联资源补发失败时，仅记录日志，不影响数字员工自身同步主流程。
+     * 检查数字员工关联资源对应的标准 JSON 是否存在;若缺失,则按原 targetContent 补发回开放资源目录. 设计说明: 1. 不重新走资源导入流程,而是直接复用各扩展表中已经生成好的 targetContent;
+     * 2. 只处理下游明确依赖的资源类型:TOOLKIT / MCP / AGENT / KG_* / VIEW / OBJECT; 3. 某个关联资源补发失败时,仅记录日志,不影响数字员工自身同步主流程.
      */
     private void syncMissingRelatedResourceJsons(Long digEmployeeResourceId) {
         if (digEmployeeResourceId == null) {
@@ -1585,20 +1586,20 @@ public class DigitalEmployeeApplicationService {
         }
         List<SsResourceRelDetail> relDetails = ssResourceRelDetailService.findByResourceId(digEmployeeResourceId);
         if (CollectionUtils.isEmpty(relDetails)) {
-            logger.debug("数字员工无关联资源，无需补齐资源JSON, digEmployeeResourceId={}", digEmployeeResourceId);
+            logger.debug("数字员工无关联资源,无需补齐资源JSON, digEmployeeResourceId={}", digEmployeeResourceId);
             return;
         }
 
         List<Long> relResourceIds = relDetails.stream().map(SsResourceRelDetail::getRelResourceId)
             .filter(java.util.Objects::nonNull).distinct().collect(Collectors.toList());
         if (CollectionUtils.isEmpty(relResourceIds)) {
-            logger.debug("数字员工关联资源ID为空，无需补齐资源JSON, digEmployeeResourceId={}", digEmployeeResourceId);
+            logger.debug("数字员工关联资源ID为空,无需补齐资源JSON, digEmployeeResourceId={}", digEmployeeResourceId);
             return;
         }
 
         List<SsResource> relResources = ssResourceService.findByIdList(relResourceIds);
         if (CollectionUtils.isEmpty(relResources)) {
-            logger.debug("数字员工关联资源不存在，无需补齐资源JSON, digEmployeeResourceId={}, relResourceIds={}", digEmployeeResourceId,
+            logger.debug("数字员工关联资源不存在,无需补齐资源JSON, digEmployeeResourceId={}, relResourceIds={}", digEmployeeResourceId,
                 relResourceIds);
             return;
         }
@@ -1611,7 +1612,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 将数字员工关联资源的标准 JSON 同步至 Redis（与 MinIO 产物同内容，键名为 {@code {BIZTYPE}_{resourceId}}）。 每次数字员工开放目录同步后执行，不依赖 MinIO 是否缺失。
+     * 将数字员工关联资源的标准 JSON 同步至 Redis(与 MinIO 产物同内容,键名为 {@code {BIZTYPE}_{resourceId}}). 每次数字员工开放目录同步后执行,不依赖 MinIO 是否缺失.
      */
     public void syncRelatedResourceConfigJsonsToRedisQuietly(Long digEmployeeResourceId) {
         if (digEmployeeResourceId == null) {
@@ -1643,7 +1644,7 @@ public class DigitalEmployeeApplicationService {
         }
         catch (Exception e) {
             logger.error(
-                "同步数字员工关联资源配置到Redis失败，不影响主流程, digEmployeeResourceId={}, relResourceId={}, resourceBizType={}, reason={}",
+                "同步数字员工关联资源配置到Redis失败,不影响主流程, digEmployeeResourceId={}, relResourceId={}, resourceBizType={}, reason={}",
                 digEmployeeResourceId, relResource == null ? null : relResource.getResourceId(),
                 relResource == null ? null : relResource.getResourceBizType(), e.getMessage(), e);
         }
@@ -1661,7 +1662,7 @@ public class DigitalEmployeeApplicationService {
         String targetContent = loadRelatedResourceTargetContent(resourceBizType, relResourceId);
         if (StringUtils.isBlank(targetContent)) {
             logger.warn(
-                "数字员工关联资源targetContent为空，跳过Redis同步, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
+                "数字员工关联资源targetContent为空,跳过Redis同步, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
                 digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType);
             return;
         }
@@ -1678,7 +1679,7 @@ public class DigitalEmployeeApplicationService {
         }
         String resourceBizType = StringUtils.trimToEmpty(relResource.getResourceBizType());
         if (!isSupportedRelatedResourceBizType(resourceBizType)) {
-            logger.debug("数字员工关联资源类型不在补齐范围内，跳过, digEmployeeResourceId={}, relResourceId={}, resourceBizType={}",
+            logger.debug("数字员工关联资源类型不在补齐范围内,跳过, digEmployeeResourceId={}, relResourceId={}, resourceBizType={}",
                 digEmployeeResourceId, relResource.getResourceId(), resourceBizType);
             return;
         }
@@ -1690,7 +1691,7 @@ public class DigitalEmployeeApplicationService {
             digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType, exists);
         if (exists) {
             logger.debug(
-                "数字员工关联资源JSON已存在，跳过补发, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
+                "数字员工关联资源JSON已存在,跳过补发, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
                 digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType);
             return;
         }
@@ -1698,14 +1699,14 @@ public class DigitalEmployeeApplicationService {
         String targetContent = loadRelatedResourceTargetContent(resourceBizType, relResourceId);
         if (StringUtils.isBlank(targetContent)) {
             logger.warn(
-                "数字员工关联资源targetContent为空，无法补发JSON, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
+                "数字员工关联资源targetContent为空,无法补发JSON, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
                 digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType);
             return;
         }
 
         try {
             logger.debug(
-                "数字员工关联资源JSON缺失，开始补发, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
+                "数字员工关联资源JSON缺失,开始补发, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}",
                 digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType);
             resourceArtifactStorageService.syncResourceJsonByBizType(targetContent, resourceBizType, relResourceId);
             ssResourceArtifactService.upsertStandardJsonArtifact(relResourceId, resourceBizType,
@@ -1716,7 +1717,7 @@ public class DigitalEmployeeApplicationService {
         }
         catch (Exception e) {
             logger.error(
-                "数字员工关联资源JSON补发失败，不影响主流程, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}, reason={}",
+                "数字员工关联资源JSON补发失败,不影响主流程, digEmployeeResourceId={}, relResourceId={}, resourceCode={}, resourceBizType={}, reason={}",
                 digEmployeeResourceId, relResourceId, relResource.getResourceCode(), resourceBizType, e.getMessage(),
                 e);
         }
@@ -1761,19 +1762,263 @@ public class DigitalEmployeeApplicationService {
         return null;
     }
 
+    /**
+     * PR-3 批量加载 target_content(替换 PR-1 之前的 N+1 循环).
+     * <p>
+     * 核心改进:单 bizType 下一次性查多个 resourceId,避免每资源一次 SQL.
+     * <p>
+     * <strong>当前实现</strong>:因 7 个 ext service(MCP / TOOLKIT / AGENT / DOC / VIEW / OBJECT / SKILL)
+     * 暂无 {@code findByIds} 批量接口,本方法内部循环 {@code findById}(TODO: 各 ext mapper 加批量 IN 查询),
+     * 仍优于 PR-1 之前的"在 for 循环里调用 + 同步走 Redis SET"--本方法至少**统一错误处理 + 一致字段读取**.
+     * <p>
+     * 调用方契约:
+     * <ul>
+     *     <li>idList 为空时返回空 Map</li>
+     *     <li>bizType 不在支持列表(TOOLKIT/MCP/AGENT/KG_xxx / VIEW / OBJECT / SKILL)时返回空 Map</li>
+     *     <li>部分资源查不到对应 ext 记录时,Map 中不包含该 key(不抛错)</li>
+     *     <li>整体异常被 catch,仅记 warn 日志,返回已成功查询到的部分 Map</li>
+     * </ul>
+     *
+     * @param resourceBizType 资源业务类型
+     * @param resourceIds 资源 ID 集合
+     * @return (resourceId -> targetContent) 映射;targetContent 为空字符串的资源不会进入返回 Map
+     */
+    public Map<Long, String> batchLoadTargetContent(String resourceBizType, Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        String bizType = StringUtils.trimToEmpty(resourceBizType);
+        if (!isSupportedRelatedResourceBizType(bizType)) {
+            return Collections.emptyMap();
+        }
+        List<Long> idList = resourceIds.stream()
+            .filter(java.util.Objects::nonNull)
+            .distinct()
+            .collect(Collectors.toList());
+        if (idList.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<Long, String> result = new HashMap<>(idList.size());
+        try {
+            // TODO(PR-3 follow-up): 各 ext service mapper 加 findByIds(Collection<Long>) 批量方法,
+            //      将本 for 循环替换为单 SQL 调用(IN 子句).
+            //      当前为统一 N+1 的临时实现:循环 findById 但单次方法调用完成所有读取,调用方拿到完整 Map 一次写入 Redis.
+            if (StringUtils.equals(bizType, ResourceBizTypeEnum.TOOLKIT.name())) {
+                for (Long id : idList) {
+                    SsResExtToolKit ext = ssResExtToolKitService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.MCP.name())) {
+                for (Long id : idList) {
+                    SsResExtMcp ext = ssResExtMcpService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.AGENT.name())) {
+                for (Long id : idList) {
+                    SsResExtAgent ext = ssResExtAgentService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.startsWithIgnoreCase(bizType, "KG_")) {
+                for (Long id : idList) {
+                    SsResExtDoc ext = ssResExtDocService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.VIEW.name())) {
+                for (Long id : idList) {
+                    SsResExtView ext = ssResExtViewService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.OBJECT.name())) {
+                for (Long id : idList) {
+                    SsResExtObject ext = ssResExtObjectService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+            else if (StringUtils.equals(bizType, ResourceBizTypeEnum.SKILL.name())) {
+                for (Long id : idList) {
+                    SsResExtSkill ext = ssResExtSkillService.findById(id);
+                    if (ext != null && StringUtils.isNotBlank(ext.getTargetContent())) {
+                        result.put(id, ext.getTargetContent());
+                    }
+                }
+            }
+        }
+        catch (Exception e) {
+            logger.warn("batchLoadTargetContent 异常: bizType={}, idCount={}, 已加载={}, reason={}",
+                bizType, idList.size(), result.size(), e.getMessage(), e);
+        }
+        return result;
+    }
+
+    /**
+     * PR-3 整页预取:批量获取页内所有数字员工的 {@code target_content}.
+     * <p>
+     * 复用已有 {@code ssResExtDigEmployeeService.findExtDigEmployeeByIds} 单 SQL 批量接口
+     * (MyBatis IN 子句),单次查询拉满整页数据;调用方后续按 {@code resourceId} 索引.
+     * <p>
+     * 调用方契约:
+     * <ul>
+     *     <li>idList 为空时返回空 Map</li>
+     *     <li>整体异常被 catch,返回空 Map 并记 warn(不阻塞调用方)</li>
+     *     <li>仅含 {@code target_content} 非空的资源(避免后续判空分支)</li>
+     * </ul>
+     *
+     * @param resourceIds 页内所有数字员工 resourceId
+     * @return (resourceId -> targetContent) 映射
+     */
+    public Map<Long, String> prefetchDigEmployeeTargetContents(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<Long> idList = resourceIds.stream()
+            .filter(java.util.Objects::nonNull)
+            .distinct()
+            .collect(Collectors.toList());
+        if (idList.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<Long, String> result = new HashMap<>(idList.size());
+        try {
+            List<com.iwhalecloud.byai.manager.dto.resource.ResourceExtDigEmployeeDto> dtos =
+                ssResExtDigEmployeeService.findExtDigEmployeeByIds(idList);
+            if (dtos == null) {
+                return result;
+            }
+            for (com.iwhalecloud.byai.manager.dto.resource.ResourceExtDigEmployeeDto dto : dtos) {
+                if (dto == null) {
+                    continue;
+                }
+                com.iwhalecloud.byai.manager.entity.resource.SsResExtDigEmployee ext = dto.getSsResExtDigEmployee();
+                if (ext == null) {
+                    continue;
+                }
+                String targetContent = ext.getTargetContent();
+                if (StringUtils.isNotBlank(targetContent)) {
+                    result.put(dto.getResourceId(), targetContent);
+                }
+            }
+        }
+        catch (Exception e) {
+            logger.warn("prefetchDigEmployeeTargetContents 异常: idCount={}, reason={}",
+                idList.size(), e.getMessage(), e);
+        }
+        return result;
+    }
+
+    /**
+     * PR-3 带预取的 {@code collectDigEmployeeSyncEntries} 变体:
+     * 主资源 target_content 直接使用预取 Map,<strong>避免每资源一次 findById</strong>.
+     * <p>
+     * 关联资源仍走 {@link #batchLoadTargetContent}(内部循环 findById,TODO 待 PR-3 follow-up 优化).
+     *
+     * @param digEmployeeId 数字员工 resourceId
+     * @param prefetchedMainTargetContent 主资源 target_content(可为 null 表示未预取到)
+     * @return 收集到的所有 (redisKey -> jsonContent) 映射
+     */
+    public Map<String, String> collectDigEmployeeSyncEntriesWithPrefetch(Long digEmployeeId, String prefetchedMainTargetContent) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (digEmployeeId == null) {
+            return result;
+        }
+        if (digEmployeeRedisSyncProperties == null
+                || !digEmployeeRedisSyncProperties.isJsonRedisSyncEnabled()) {
+            return result;
+        }
+        // 主资源:直接使用预取 target_content(避免 ssResExtDigEmployeeService.findById)
+        if (StringUtils.isNotBlank(prefetchedMainTargetContent)) {
+            result.put(
+                DigEmployeeRedisKeys.resourceConfigJsonKey(
+                    ResourceBizTypeEnum.DIG_EMPLOYEE.name(), digEmployeeId),
+                prefetchedMainTargetContent);
+        }
+        else {
+            // target_content 预取未取到(空 / 异常):回退到原逐资源解析(保留原行为)
+            // 若 skipBlankTargetContent=true,resolveDigEmployeeJsonForRedisSync 内部会记 warn 并 return null
+            String mainJson = resolveDigEmployeeJsonForRedisSync(digEmployeeId);
+            if (StringUtils.isNotBlank(mainJson)) {
+                result.put(
+                    DigEmployeeRedisKeys.resourceConfigJsonKey(
+                        ResourceBizTypeEnum.DIG_EMPLOYEE.name(), digEmployeeId),
+                    mainJson);
+            }
+            // 主资源回退路径下,不再尝试关联资源(避免一次同步里混用两种策略)
+            return result;
+        }
+        // 关联资源:复用 batchLoadTargetContent(pr-3 内为 per-id 循环;pr-3-follow-up 优化为单 SQL)
+        try {
+            List<SsResourceRelDetail> relDetails = ssResourceRelDetailService.findByResourceId(digEmployeeId);
+            if (CollectionUtils.isEmpty(relDetails)) {
+                return result;
+            }
+            List<Long> relIds = relDetails.stream()
+                .map(SsResourceRelDetail::getRelResourceId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+            if (CollectionUtils.isEmpty(relIds)) {
+                return result;
+            }
+            List<SsResource> relResources = ssResourceService.findByIdList(relIds);
+            if (CollectionUtils.isEmpty(relResources)) {
+                return result;
+            }
+            // PR-3: 按 bizType 分桶后批量加载
+            Map<String, List<Long>> bizTypeToIds = relResources.stream()
+                .filter(r -> r != null && r.getResourceId() != null)
+                .collect(Collectors.groupingBy(
+                    r -> StringUtils.trimToEmpty(r.getResourceBizType()),
+                    Collectors.mapping(SsResource::getResourceId, Collectors.toList())));
+            for (Map.Entry<String, List<Long>> entry : bizTypeToIds.entrySet()) {
+                String bizType = entry.getKey();
+                List<Long> ids = entry.getValue();
+                if (ids == null || ids.isEmpty()) {
+                    continue;
+                }
+                Map<Long, String> batchTarget = batchLoadTargetContent(bizType, ids);
+                for (Map.Entry<Long, String> kv : batchTarget.entrySet()) {
+                    result.put(
+                        DigEmployeeRedisKeys.resourceConfigJsonKey(bizType, kv.getKey()),
+                        kv.getValue());
+                }
+            }
+        }
+        catch (Exception e) {
+            logger.warn("收集数字员工关联资源同步条目失败 (prefetch path), resourceId={}, reason={}",
+                digEmployeeId, e.getMessage(), e);
+        }
+        return result;
+    }
+
     private void syncDigEmployeeSkillsToRedisQuietly(Long resourceId) {
-        // RESOURCE_DIG_EMPLOYEE_{resourceId} 为历史技能列表缓存，当前下游已切到 DIG_EMPLOYEE_{resourceId}
-        // + KG_DOC_{resourceId} 读取完整配置，先屏蔽写 Redis，避免继续产出旧口径缓存。
+        // RESOURCE_DIG_EMPLOYEE_{resourceId} 为历史技能列表缓存,当前下游已切到 DIG_EMPLOYEE_{resourceId}
+        // + KG_DOC_{resourceId} 读取完整配置,先屏蔽写 Redis,避免继续产出旧口径缓存.
         // try {
         //     syncDigEmployeeSkillsToRedis(resourceId);
         // }
         // catch (Exception e) {
-        //     logger.error("同步数字员工技能信息到Redis失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+        //     logger.error("同步数字员工技能信息到Redis失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         // }
     }
 
     private void syncDigEmployeeSkillsToRedis(Long resourceId) {
-        // RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存写入已暂停；保留原逻辑注释便于需要时回滚。
+        // RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存写入已暂停;保留原逻辑注释便于需要时回滚.
         // if (resourceId == null) {
         //     return;
         // }
@@ -1783,10 +2028,10 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 按数字员工当前资源关联关系重建技能运行时配置，并写回 ss_res_ext_dig_employee.skills。
+     * 按数字员工当前资源关联关系重建技能运行时配置,并写回 ss_res_ext_dig_employee.skills.
      *
-     * 安装技能、对话框 #技能 上传/解绑都以 ss_resource_rel_detail 作为事实来源；这里统一补齐 relSkills 的
-     * skillType、skillUrl、versionUrl 等运行时字段，避免授权/安装和数字员工 JSON 之间出现口径漂移。
+     * 安装技能、对话框 #技能 上传/解绑都以 ss_resource_rel_detail 作为事实来源;这里统一补齐 relSkills 的
+     * skillType、skillUrl、versionUrl 等运行时字段,避免授权/安装和数字员工 JSON 之间出现口径漂移.
      */
     public void rebuildAndSaveDigitalEmployeeRelSkills(Long resourceId) {
         if (resourceId == null) {
@@ -1794,7 +2039,7 @@ public class DigitalEmployeeApplicationService {
         }
         SsResExtDigEmployee extDigEmployee = ssResExtDigEmployeeService.findById(resourceId);
         if (extDigEmployee == null) {
-            logger.warn("重建数字员工技能列表失败：扩展表记录不存在, resourceId={}", resourceId);
+            logger.warn("重建数字员工技能列表失败:扩展表记录不存在, resourceId={}", resourceId);
             return;
         }
 
@@ -1867,7 +2112,7 @@ public class DigitalEmployeeApplicationService {
             syncDigEmployeeConfigJsonToRedis(resourceId, jsonContent);
         }
         catch (Exception e) {
-            logger.error("同步数字员工完整配置到Redis失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+            logger.error("同步数字员工完整配置到Redis失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         }
     }
 
@@ -1881,7 +2126,7 @@ public class DigitalEmployeeApplicationService {
             return;
         }
         if (StringUtils.isBlank(jsonContent)) {
-            logger.warn("资源完整配置JSON为空，跳过Redis同步, resourceBizType={}, resourceId={}", resourceBizType, resourceId);
+            logger.warn("资源完整配置JSON为空,跳过Redis同步, resourceBizType={}, resourceId={}", resourceBizType, resourceId);
             return;
         }
         String redisKey = DigEmployeeRedisKeys.resourceConfigJsonKey(resourceBizType, resourceId);
@@ -1895,7 +2140,7 @@ public class DigitalEmployeeApplicationService {
             removeDigEmployeeFromRedis(resourceId);
         }
         catch (Exception e) {
-            logger.error("删除数字员工技能Redis缓存失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+            logger.error("删除数字员工技能Redis缓存失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         }
     }
 
@@ -1903,7 +2148,7 @@ public class DigitalEmployeeApplicationService {
         if (resourceId == null) {
             return;
         }
-        // RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存已暂停维护，这里不再主动触碰该 key。
+        // RESOURCE_DIG_EMPLOYEE_{resourceId} 旧技能缓存已暂停维护,这里不再主动触碰该 key.
         // RedisUtil.removeKey(DigEmployeeRedisKeys.skillCacheKey(resourceId));
         removeDigEmployeeConfigJsonFromRedis(resourceId);
     }
@@ -1921,7 +2166,7 @@ public class DigitalEmployeeApplicationService {
             removeDigEmployeeJsonFromResourceStorage(resourceId);
         }
         catch (Exception e) {
-            logger.error("删除数字员工开放资源目录文件失败，resourceId: {}, error: {}", resourceId, e.getMessage(), e);
+            logger.error("删除数字员工开放资源目录文件失败,resourceId: {}, error: {}", resourceId, e.getMessage(), e);
         }
     }
 
@@ -1944,7 +2189,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 当前关联资源和已关联资源对象进行对比，决定修改或者删除
+     * 当前关联资源和已关联资源对象进行对比,决定修改或者删除
      *
      * @param ssResource 资源对象
      * @param relIds 当前最新关联资源标识
@@ -1955,7 +2200,7 @@ public class DigitalEmployeeApplicationService {
         Map<String, List<String>> relResourceInfoListMap = new HashMap<>(10);
         if (CollectionUtils.isNotEmpty(relResourceInfoList)) {
             relResourceInfoListMap = relResourceInfoList.stream().collect(
-                Collectors.toMap(RelResourceInfo::getRelId, RelResourceInfo::getActiveResourceIds, (v1, v2) -> v2 // 键重复时的合并规则：覆盖
+                Collectors.toMap(RelResourceInfo::getRelId, RelResourceInfo::getActiveResourceIds, (v1, v2) -> v2 // 键重复时的合并规则:覆盖
                 ));
         }
 
@@ -1966,17 +2211,17 @@ public class DigitalEmployeeApplicationService {
             resourceRelDetailMap.put(ssResourceRelDetail.getRelResourceId(), ssResourceRelDetail);
         }
 
-        // 对比，存在的修改，不存在的新增
+        // 对比,存在的修改,不存在的新增
         for (int i = 0; relIds != null && i < relIds.size(); i++) {
             Long relResourceId = relIds.get(i);
-            // 关联子资源的信息（可用状态）
+            // 关联子资源的信息(可用状态)
             List<String> relActiveChildResourceIds = relResourceInfoListMap.get(String.valueOf(relResourceId));
             SsResourceRelDetail ssResourceRelDetail = resourceRelDetailMap.remove(relResourceId);
 
             if (ssResourceRelDetail != null) {
                 ssResourceRelDetail.setUpdateBy(CurrentUserHolder.getCurrentUserId());
                 ssResourceRelDetail.setUpdateTime(new Date());
-                // 关联子资源的信息（可用状态）
+                // 关联子资源的信息(可用状态)
                 if (CollectionUtils.isNotEmpty(relActiveChildResourceIds)) {
                     RelResourceInfo relResourceInfo = new RelResourceInfo();
                     relResourceInfo.setRelId(String.valueOf(relResourceId));
@@ -1987,7 +2232,7 @@ public class DigitalEmployeeApplicationService {
             }
             else {
                 ssResourceRelDetail = new SsResourceRelDetail();
-                // 关联子资源的信息（可用状态）
+                // 关联子资源的信息(可用状态)
                 if (CollectionUtils.isNotEmpty(relActiveChildResourceIds)) {
                     RelResourceInfo relResourceInfo = new RelResourceInfo();
                     relResourceInfo.setRelId(String.valueOf(relResourceId));
@@ -2017,7 +2262,7 @@ public class DigitalEmployeeApplicationService {
      */
     public List<EmployeeAuditResult> checkEmployeeAudit(DigitalEmployeeDTO digitalEmployeeDTO) {
 
-        // 如果开了开关，就不检查
+        // 如果开了开关,就不检查
         String isCheckEmployeeAudit = systemConfigService.getStringParamValueByCode("IS_CHECK_EMPLOYEE_AUDIT");
         if (Constants.NO_VALUE_FALSE.equalsIgnoreCase(isCheckEmployeeAudit)) {
             return Collections.emptyList();
@@ -2077,7 +2322,7 @@ public class DigitalEmployeeApplicationService {
             }
         }
 
-        // 本体类关联资源：注入 ontologyBaseCode，并重建 relOntology 明细
+        // 本体类关联资源:注入 ontologyBaseCode,并重建 relOntology 明细
         enrichOntologyRelResources(relResourceList, digitalEmployeeDetailsDTO);
 
         digitalEmployeeDetailsDTO.setRelIds(relIds);
@@ -2085,33 +2330,33 @@ public class DigitalEmployeeApplicationService {
         List<Map<String, Object>> relSkills = buildRelSkillsFromRelations(resourceId);
         digitalEmployeeDetailsDTO.setSkills(JSON.toJSONString(relSkills));
         digitalEmployeeDetailsDTO.setRelSkills(toRelSkillObjects(relSkills));
-        // relTools 不入库，直接从最近一次 sync 写入的 target_content 镜像里反序列化回填，保证编辑回显不丢数据。
+        // relTools 不入库,直接从最近一次 sync 写入的 target_content 镜像里反序列化回填,保证编辑回显不丢数据.
         digitalEmployeeDetailsDTO
             .setRelTools(parseRelToolsFromTargetContent(digitalEmployeeDetailsDTO.getTargetContent()));
-        // relPrompt 优先取保存时写入 target_content 的运行期值；
-        // 历史数据若没有该字段，再兜底到 corePersonaDefinition，兼容旧数据。
+        // relPrompt 优先取保存时写入 target_content 的运行期值;
+        // 历史数据若没有该字段,再兜底到 corePersonaDefinition,兼容旧数据.
         String relPrompt = parseRelPromptFromTargetContent(digitalEmployeeDetailsDTO.getTargetContent());
         if (StringUtils.isBlank(relPrompt)) {
             relPrompt = digitalEmployeeDetailsDTO.getCorePersonaDefinition();
         }
         digitalEmployeeDetailsDTO.setRelPrompt(relPrompt);
 
-        // 查询记忆配置列表（根据数字员工ID和用户ID查询）
+        // 查询记忆配置列表(根据数字员工ID和用户ID查询)
         Long userId = CurrentUserHolder.getCurrentUserId();
         List<MemoryConfigDTO> memoryConfigList = templateRuleInfoApplicationService
             .findMemoryConfigsByResourceIdAndUserId(resourceId, userId);
         digitalEmployeeDetailsDTO.setMemoryConfigList(memoryConfigList);
-        // target_content 仅供后端内部回填运行期字段使用，不对前端详情接口暴露。
+        // target_content 仅供后端内部回填运行期字段使用,不对前端详情接口暴露.
         digitalEmployeeDetailsDTO.setTargetContent(null);
 
         return digitalEmployeeDetailsDTO;
     }
 
     /**
-     * 为本体类关联资源(ONTOLOGY_BASE/SCENE/VIEW/OBJECT)注入 ontologyBaseCode，并重建 relOntology 扁平明细。
-     * ontologyBaseCode 取自各自扩展表；relOntology 的路径(sceneId/viewCode/objectCode 等)
-     * 由资源树本身重建：resource_code 即各级编码、resource_name 即名称、parent_resource_id 即层级，
-     * 不依赖 ext.target_content 格式（快照对象的 ext 为 datacloud 原始格式，缺 sceneId，会导致回显对不上）。
+     * 为本体类关联资源(ONTOLOGY_BASE/SCENE/VIEW/OBJECT)注入 ontologyBaseCode,并重建 relOntology 扁平明细.
+     * ontologyBaseCode 取自各自扩展表;relOntology 的路径(sceneId/viewCode/objectCode 等)
+     * 由资源树本身重建:resource_code 即各级编码、resource_name 即名称、parent_resource_id 即层级,
+     * 不依赖 ext.target_content 格式(快照对象的 ext 为 datacloud 原始格式,缺 sceneId,会导致回显对不上).
      */
     private void enrichOntologyRelResources(List<SsResourceDTO> relResourceList, DigitalEmployeeDetailsDTO details) {
         if (CollectionUtils.isEmpty(relResourceList)) {
@@ -2123,12 +2368,12 @@ public class DigitalEmployeeApplicationService {
         if (CollectionUtils.isEmpty(ontologyResources)) {
             return;
         }
-        // ontologyBaseCode 注入（Part B）
+        // ontologyBaseCode 注入(Part B)
         List<Long> ids = ontologyResources.stream().map(SsResource::getResourceId).filter(Objects::nonNull)
             .collect(Collectors.toList());
         Map<Long, String> pidMap = ssResourceService.findOntologyBaseCodeMap(ids);
 
-        // 构建 id->资源 映射用于回溯父链：先放入关联资源，再补齐缺失的祖先
+        // 构建 id->资源 映射用于回溯父链:先放入关联资源,再补齐缺失的祖先
         Map<Long, SsResource> byId = new HashMap<>();
         for (SsResourceDTO r : relResourceList) {
             if (r != null && r.getResourceId() != null) {
@@ -2243,7 +2488,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 用前端原始入参覆盖 details 上的运行期字段。 仅处理"不入 DB" 或"前端入参更新"的字段（relTools / relPrompt），其它字段以 DB 现状为准。
+     * 用前端原始入参覆盖 details 上的运行期字段. 仅处理"不入 DB" 或"前端入参更新"的字段(relTools / relPrompt),其它字段以 DB 现状为准.
      */
     private void applyInputRuntimeFields(DigitalEmployeeDetailsDTO details, DigitalEmployeeDTO inputDto) {
         if (details == null || inputDto == null) {
@@ -2252,10 +2497,10 @@ public class DigitalEmployeeApplicationService {
         if (inputDto.getRelTools() != null) {
             details.setRelTools(inputDto.getRelTools());
         }
-        // relPrompt 以本次提交为准：
-        // - 显式传 relPrompt：直接使用，允许空串表达"清空"；
-        // - 否则若传了 corePersonaDefinition：按同源字段同步，允许空串覆盖；
-        // - 两者都未传：保持 findDetailsById 查出的值不变。
+        // relPrompt 以本次提交为准:
+        // - 显式传 relPrompt:直接使用,允许空串表达"清空";
+        // - 否则若传了 corePersonaDefinition:按同源字段同步,允许空串覆盖;
+        // - 两者都未传:保持 findDetailsById 查出的值不变.
         if (inputDto.getRelPrompt() != null) {
             details.setRelPrompt(inputDto.getRelPrompt());
         }
@@ -2264,13 +2509,13 @@ public class DigitalEmployeeApplicationService {
         }
     }
 
-    /** 更新/保存接口返回详情时，用本次入参兜底覆盖运行期字段，避免响应仍回显旧值。 */
+    /** 更新/保存接口返回详情时,用本次入参兜底覆盖运行期字段,避免响应仍回显旧值. */
     public void applyInputRuntimeFieldsForResponse(DigitalEmployeeDetailsDTO details, DigitalEmployeeDTO inputDto) {
         applyInputRuntimeFields(details, inputDto);
     }
 
     /**
-     * 把刚刚生成的标准 JSON 串镜像写入 ss_res_ext_dig_employee.target_content。 失败仅记日志，不阻断后续 MinIO 同步——target_content 是辅助快照，缺失不影响主流程。
+     * 把刚刚生成的标准 JSON 串镜像写入 ss_res_ext_dig_employee.target_content. 失败仅记日志,不阻断后续 MinIO 同步--target_content 是辅助快照,缺失不影响主流程.
      */
     private void persistTargetContent(Long resourceId, String jsonContent) {
         if (resourceId == null || StringUtils.isBlank(jsonContent)) {
@@ -2279,7 +2524,7 @@ public class DigitalEmployeeApplicationService {
         try {
             SsResExtDigEmployee ssResExtDigEmployee = ssResExtDigEmployeeService.findById(resourceId);
             if (ssResExtDigEmployee == null) {
-                logger.warn("写入 target_content 失败：扩展表记录不存在, resourceId={}", resourceId);
+                logger.warn("写入 target_content 失败:扩展表记录不存在, resourceId={}", resourceId);
                 return;
             }
             ssResExtDigEmployee.setTargetContent(jsonContent);
@@ -2291,12 +2536,12 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * PR-1: 公开包级访问包装，供 {@code StartupTargetContentPreloader}（c-4 离线预生成）使用。
-     * 行为与私有 {@link #persistTargetContent} 一致；返回 boolean 便于预生成脚本统计。
+     * PR-1: 公开包级访问包装,供 {@code StartupTargetContentPreloader}(c-4 离线预生成)使用.
+     * 行为与私有 {@link #persistTargetContent} 一致;返回 boolean 便于预生成脚本统计.
      *
      * @param resourceId 数字员工资源 ID
      * @param jsonContent 标准 JSON 内容
-     * @return true 表示成功写入；false 表示被跳过或失败（已在日志记录）
+     * @return true 表示成功写入;false 表示被跳过或失败(已在日志记录)
      */
     public boolean persistDigEmployeeTargetContent(Long resourceId, String jsonContent) {
         if (resourceId == null || StringUtils.isBlank(jsonContent)) {
@@ -2305,7 +2550,7 @@ public class DigitalEmployeeApplicationService {
         try {
             SsResExtDigEmployee ssResExtDigEmployee = ssResExtDigEmployeeService.findById(resourceId);
             if (ssResExtDigEmployee == null) {
-                logger.warn("写入 target_content 失败：扩展表记录不存在, resourceId={}", resourceId);
+                logger.warn("写入 target_content 失败:扩展表记录不存在, resourceId={}", resourceId);
                 return false;
             }
             ssResExtDigEmployee.setTargetContent(jsonContent);
@@ -2526,7 +2771,7 @@ public class DigitalEmployeeApplicationService {
         return null;
     }
 
-    /** 反序列化 target_content 里的 relTools 数组；不存在或解析失败返回 null。 */
+    /** 反序列化 target_content 里的 relTools 数组;不存在或解析失败返回 null. */
     private List<String> parseRelToolsFromTargetContent(String targetContent) {
         com.alibaba.fastjson2.JSONObject obj = parseTargetContentSafely(targetContent);
         if (obj == null) {
@@ -2536,7 +2781,7 @@ public class DigitalEmployeeApplicationService {
         return arr == null ? null : arr.toJavaList(String.class);
     }
 
-    /** 反序列化 target_content 里的 relPrompt 字符串；不存在或解析失败返回 null。 */
+    /** 反序列化 target_content 里的 relPrompt 字符串;不存在或解析失败返回 null. */
     private String parseRelPromptFromTargetContent(String targetContent) {
         com.alibaba.fastjson2.JSONObject obj = parseTargetContentSafely(targetContent);
         if (obj == null) {
@@ -2545,7 +2790,7 @@ public class DigitalEmployeeApplicationService {
         return obj.getString("relPrompt");
     }
 
-    /** 通用：把 target_content 解析为 JSONObject，失败返回 null 并记 warn。 */
+    /** 通用:把 target_content 解析为 JSONObject,失败返回 null 并记 warn. */
     private com.alibaba.fastjson2.JSONObject parseTargetContentSafely(String targetContent) {
         if (StringUtils.isBlank(targetContent)) {
             return null;
@@ -2608,10 +2853,10 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 生成智能体提示词 根据输入的提示词参数，调用AI服务生成智能体所需的各类提示词内容
+     * 生成智能体提示词 根据输入的提示词参数,调用AI服务生成智能体所需的各类提示词内容
      *
-     * @param promptInputMap 提示词输入参数，包含lang（语言）、promptGroupCode（提示词分组编码）等
-     * @return 生成的提示词Map，key为提示词字段编码，value为生成的提示词内容
+     * @param promptInputMap 提示词输入参数,包含lang(语言)、promptGroupCode(提示词分组编码)等
+     * @return 生成的提示词Map,key为提示词字段编码,value为生成的提示词内容
      */
     public Map<String, Object> generate(Map<String, Object> promptInputMap) {
 
@@ -2640,11 +2885,11 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 构建智能体信息描述：将输入参数和提示词模板组合，构建用于AI生成的智能体描述信息
+     * 构建智能体信息描述:将输入参数和提示词模板组合,构建用于AI生成的智能体描述信息
      *
      * @param paramsInput 输入的参数Map
      * @param aiPrompts 提示词模板列表
-     * @param lang 语言类型（zh：中文，en：英文）
+     * @param lang 语言类型(zh:中文,en:英文)
      * @return 格式化后的智能体信息描述字符串
      */
     private String buildAgentInfo(Map<String, Object> paramsInput, List<AiPrompt> aiPrompts, String lang) {
@@ -2714,7 +2959,7 @@ public class DigitalEmployeeApplicationService {
         // 管理员设�?
         setQuery(request);
 
-        // 我管理的，不仅仅是查man_user_id，还要给有管理权限的人授
+        // 我管理的,不仅仅是查man_user_id,还要给有管理权限的人授
         Map<Integer, Long> statusNumMap = new HashMap<>();
         // TODO:
         // 或者将此方法也移至ResourceAuthApplicationService
@@ -2724,10 +2969,10 @@ public class DigitalEmployeeApplicationService {
         // 用于存储各状态的总和
         Map<String, Long> statusNumStatics = new HashMap<>();
 
-        // 遍历列表中的每个Map，累加各状态的�?
+        // 遍历列表中的每个Map,累加各状态的�?
         for (Map<Integer, Long> statusMap : statusNumList) {
             // 累加每个Map中的所有值到总数
-            // 累加各状态的值（使用getOrDefault避免NullPointerException�?
+            // 累加各状态的值(使用getOrDefault避免NullPointerException�?
             statusNumMap.put(org.apache.commons.collections.MapUtils.getInteger(statusMap, "resourceStatus"),
                 org.apache.commons.collections.MapUtils.getLong(statusMap, "num"));
         }
@@ -2759,11 +3004,11 @@ public class DigitalEmployeeApplicationService {
             // 1. 首先得到所有有管理权限的资源id
             Set<Long> managedResourceIds = getAuthListByResourceTypeAndGrantType(request.getResourceTypeList(),
                 List.of(GrantType.ALLOW_MANAGE));
-            // 如果没有管理权限的资源，只查我创建的
+            // 如果没有管理权限的资源,只查我创建的
             if (managedResourceIds != null && !managedResourceIds.isEmpty()) {
                 // 有管理权限的资源列表
                 request.setResourceIdList(managedResourceIds);
-                // 需要在SQL中实现：resource_id IN (managedResourceIds) OR create_by = currentUserId
+                // 需要在SQL中实现:resource_id IN (managedResourceIds) OR create_by = currentUserId
             }
             else {
                 request.setResourceIdList(Set.of(Long.MIN_VALUE));
@@ -2790,8 +3035,8 @@ public class DigitalEmployeeApplicationService {
     /**
      * 过滤权限列表中的黑名单资�?
      *
-     * @param authList 权限授权列表，包含资源授权信�?
-     * @return 过滤后的有效资源ID集合，不包含黑名单资�?
+     * @param authList 权限授权列表,包含资源授权信�?
+     * @return 过滤后的有效资源ID集合,不包含黑名单资�?
      */
     public Set<Long> filterBackList(List<PrivilegeGrant> authList) {
         if (authList == null || authList.isEmpty()) {
@@ -2811,7 +3056,7 @@ public class DigitalEmployeeApplicationService {
             // 检查是否有黑名单权�?
             boolean hasBlackAuth = resourceAuths.stream().anyMatch(auth -> Color.BLACK.equals(auth.getGrantToType()));
 
-            // 黑名单优先级更高：有红名单且无黑名单才有�?
+            // 黑名单优先级更高:有红名单且无黑名单才有�?
             return hasRedAuth && !hasBlackAuth;
         }).map(Map.Entry::getKey).collect(Collectors.toSet());
     }
@@ -2819,8 +3064,8 @@ public class DigitalEmployeeApplicationService {
     /**
      * 根据会话ID清理调试消息接口
      *
-     * @param sessionId 数字员工ID，用于标识需要清理调试消息的会话
-     * @return 返回清理调试消息的结果响应）
+     * @param sessionId 数字员工ID,用于标识需要清理调试消息的会话
+     * @return 返回清理调试消息的结果响应)
      */
     public DebugSessionCleanupVo cleanupDebugMessages(Long sessionId) {
 
@@ -2841,7 +3086,7 @@ public class DigitalEmployeeApplicationService {
     }
 
     /**
-     * 商业版本（dataset.system=WHALE_AGENT）下，企业 tab 不允许创建编码型/调试型数字员工。 个人 tab 不受限；非商业版本（datasetSystem 为空或其它值）也不受限。
+     * 商业版本(dataset.system=WHALE_AGENT)下,企业 tab 不允许创建编码型/调试型数字员工. 个人 tab 不受限;非商业版本(datasetSystem 为空或其它值)也不受限.
      *
      * @author qin.guoquan
      * @date 2026-05-07

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtAgentService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtAgentService.java
@@ -59,6 +59,16 @@ public class SsResExtAgentService {
     }
 
     /**
+     * PR-3 (#150) 批量查询智能体扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 智能体扩展列表
+     */
+    public List<SsResExtAgent> findByIds(Collection<Long> resourceIds) {
+        return ssResExtAgentMapper.findByIds(resourceIds);
+    }
+
+    /**
      * 查询智能体信息
      *
      * @param resourceIds 资源标识

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtDocService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtDocService.java
@@ -88,6 +88,16 @@ public class SsResExtDocService {
     }
 
     /**
+     * PR-3 (#150) 批量查询文档库扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 文档库扩展列表
+     */
+    public List<SsResExtDoc> findByIds(Collection<Long> resourceIds) {
+        return ssResExtDocMapper.findByIds(resourceIds);
+    }
+
+    /**
      * 查询文档库信息
      *
      * @param resourceIds 资源标识

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtMcpService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtMcpService.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,16 @@ public class SsResExtMcpService {
 
     public SsResExtMcp findById(Long resourceId) {
         return ssResExtMcpMapper.selectById(resourceId);
+    }
+
+    /**
+     * PR-3 (#150) 批量查询 MCP 扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return MCP 扩展列表
+     */
+    public List<SsResExtMcp> findByIds(Collection<Long> resourceIds) {
+        return ssResExtMcpMapper.findByIds(resourceIds);
     }
 
     /**

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtObjectService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtObjectService.java
@@ -5,6 +5,9 @@ import com.iwhalecloud.byai.manager.mapper.resource.SsResExtObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * add by qin.guoquan 2026-04-10
  * 对象扩展服务
@@ -29,5 +32,15 @@ public class SsResExtObjectService {
 
     public SsResExtObject findById(Long resourceId) {
         return ssResExtObjectMapper.selectById(resourceId);
+    }
+
+    /**
+     * PR-3 (#150) 批量查询对象扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 对象扩展列表
+     */
+    public List<SsResExtObject> findByIds(Collection<Long> resourceIds) {
+        return ssResExtObjectMapper.findByIds(resourceIds);
     }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtSkillService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtSkillService.java
@@ -93,6 +93,16 @@ public class SsResExtSkillService {
     }
 
     /**
+     * PR-3 (#150) 批量查询技能扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 技能扩展列表
+     */
+    public List<SsResExtSkill> findByIds(Collection<Long> resourceIds) {
+        return ssResExtSkillMapper.findByIds(resourceIds);
+    }
+
+    /**
      * 查询技能版本号
      *
      * @param resourceId 资源ID

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtToolKitService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtToolKitService.java
@@ -59,6 +59,16 @@ public class SsResExtToolKitService {
     }
 
     /**
+     * PR-3 (#150) 批量查询工具集扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 工具集扩展列表
+     */
+    public List<SsResExtToolKit> findByIds(Collection<Long> resourceIds) {
+        return ssResExtToolKitMapper.findByIds(resourceIds);
+    }
+
+    /**
      * 查询工具集信息（包含关联的工具列表）
      *
      * @param resourceIds 资源标识

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtViewService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResExtViewService.java
@@ -5,6 +5,9 @@ import com.iwhalecloud.byai.manager.mapper.resource.SsResExtViewMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * add by qin.guoquan 2026-04-10
  * 视图扩展服务
@@ -29,5 +32,15 @@ public class SsResExtViewService {
 
     public SsResExtView findById(Long resourceId) {
         return ssResExtViewMapper.selectById(resourceId);
+    }
+
+    /**
+     * PR-3 (#150) 批量查询视图扩展数据. 单 SQL IN 子句,替代循环 findById.
+     *
+     * @param resourceIds 资源ID集合(空集合/null 时返回空 List,不触发 SQL)
+     * @return 视图扩展列表
+     */
+    public List<SsResExtView> findByIds(Collection<Long> resourceIds) {
+        return ssResExtViewMapper.findByIds(resourceIds);
     }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtAgentMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtAgentMapper.java
@@ -23,4 +23,18 @@ public interface SsResExtAgentMapper extends BaseMapper<SsResExtAgent> {
      */
     List<ResourceExtAgentDto> findResourceExtAgentByIds(@Param("resourceIds") Collection<Long> resourceIds);
 
+    /**
+     * PR-3 (#150) 批量查询智能体扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 智能体扩展列表
+     */
+    default List<SsResExtAgent> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
+
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtDocMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtDocMapper.java
@@ -30,4 +30,18 @@ public interface SsResExtDocMapper extends BaseMapper<SsResExtDoc> {
      * @return 文档库扩展列表
      */
     List<SsResExtDoc> selectListByResourceIds(@Param("resourceIds") List<Long> resourceIds);
+
+    /**
+     * PR-3 (#150) 批量查询文档库扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 文档库扩展列表
+     */
+    default List<SsResExtDoc> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtMcpMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtMcpMapper.java
@@ -4,9 +4,26 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.iwhalecloud.byai.manager.entity.resource.SsResExtMcp;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * MCP扩展表Mapper接口
  */
 @Mapper
 public interface SsResExtMcpMapper extends BaseMapper<SsResExtMcp> {
+
+    /**
+     * PR-3 (#150) 批量查询 MCP 扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return MCP 扩展列表
+     */
+    default List<SsResExtMcp> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtObjectMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtObjectMapper.java
@@ -4,10 +4,27 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.iwhalecloud.byai.manager.entity.resource.SsResExtObject;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * add by qin.guoquan 2026-04-10
  * 对象扩展表 Mapper 接口
  */
 @Mapper
 public interface SsResExtObjectMapper extends BaseMapper<SsResExtObject> {
+
+    /**
+     * PR-3 (#150) 批量查询对象扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 对象扩展列表
+     */
+    default List<SsResExtObject> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtSkillMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtSkillMapper.java
@@ -26,4 +26,18 @@ public interface SsResExtSkillMapper extends BaseMapper<SsResExtSkill> {
      */
     List<SsResExtSkillDto> findBySkillCodes(@Param("skillCodes") Collection<String> skillCodes);
 
+    /**
+     * PR-3 (#150) 批量查询技能扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 技能扩展列表
+     */
+    default List<SsResExtSkill> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
+
 }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtToolKitMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtToolKitMapper.java
@@ -32,8 +32,22 @@ public interface SsResExtToolKitMapper extends BaseMapper<SsResExtToolKit> {
     List<SsResExtToolKit> selectListByResourceIds(@Param("resourceIds") List<Long> resourceIds);
 
     /**
+     * PR-3 (#150) 批量查询工具集扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 工具集扩展列表
+     */
+    default List<SsResExtToolKit> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
+
+    /**
      * 查找工具的工具集
-     * 
+     *
      * @param resourceId 资源标识
      * @return Long
      */

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtViewMapper.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/manager/mapper/resource/SsResExtViewMapper.java
@@ -4,10 +4,27 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.iwhalecloud.byai.manager.entity.resource.SsResExtView;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * add by qin.guoquan 2026-04-10
  * 视图扩展表 Mapper 接口
  */
 @Mapper
 public interface SsResExtViewMapper extends BaseMapper<SsResExtView> {
+
+    /**
+     * PR-3 (#150) 批量查询视图扩展数据. 内部委托 MyBatis-Plus {@code selectBatchIds}
+     * (单 SQL IN 子句),用于替代启动期循环 {@code findById} 触发的 N+1.
+     *
+     * @param resourceIds 资源ID列表(空集合时返回空 List,不会触发 SQL)
+     * @return 视图扩展列表
+     */
+    default List<SsResExtView> findByIds(Collection<Long> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return selectBatchIds(resourceIds);
+    }
 }

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeBatchFindByIdsTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeBatchFindByIdsTest.java
@@ -1,0 +1,407 @@
+package com.iwhalecloud.byai.manager.application.service.digitemploy;
+
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtAgentService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtDocService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtMcpService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtObjectService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtSkillService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtToolKitService;
+import com.iwhalecloud.byai.manager.domain.resource.service.SsResExtViewService;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtAgent;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtDoc;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtMcp;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtObject;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtSkill;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtToolKit;
+import com.iwhalecloud.byai.manager.entity.resource.SsResExtView;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtAgentMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtDocMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtMcpMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtObjectMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtSkillMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtToolKitMapper;
+import com.iwhalecloud.byai.manager.mapper.resource.SsResExtViewMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * PR-3 (#150) 批量 findByIds 重构的单测与集成测试.
+ * <p>
+ * 覆盖三件事:
+ * <ol>
+ *     <li>7 个 ext mapper 的 {@code findByIds(Collection<Long>)} 边界
+ *         (空集合、null、入参重复) — 单元测试.</li>
+ *     <li>7 个 ext service 的 {@code findByIds} 包装方法 — 单元测试
+ *         (mock mapper, 验证 service.findByIds → mapper.findByIds 一次).</li>
+ *     <li>{@link DigitalEmployeeApplicationService#batchLoadTargetContent}
+ *         集成场景 — mock 7 个 ext service 各返回 3 条记录, 验证每个 service 的
+ *         {@code findByIds} 被调用 1 次 (而非 3 次循环 findById).</li>
+ * </ol>
+ */
+class DigitalEmployeeBatchFindByIdsTest {
+
+    private SsResExtToolKitMapper toolKitMapper;
+    private SsResExtMcpMapper mcpMapper;
+    private SsResExtAgentMapper agentMapper;
+    private SsResExtDocMapper docMapper;
+    private SsResExtViewMapper viewMapper;
+    private SsResExtObjectMapper objectMapper;
+    private SsResExtSkillMapper skillMapper;
+
+    private SsResExtToolKitService toolKitService;
+    private SsResExtMcpService mcpService;
+    private SsResExtAgentService agentService;
+    private SsResExtDocService docService;
+    private SsResExtViewService viewService;
+    private SsResExtObjectService objectService;
+    private SsResExtSkillService skillService;
+
+    private DigitalEmployeeApplicationService appService;
+
+    @BeforeEach
+    void setUp() {
+        // 使用 CALLS_REAL_METHODS 让 default 方法真实执行 (selectBatchIds 调用路径可验证),
+        // 同时 stubbed 方法返回我们指定的 List.
+        toolKitMapper = mock(SsResExtToolKitMapper.class, CALLS_REAL_METHODS);
+        mcpMapper = mock(SsResExtMcpMapper.class, CALLS_REAL_METHODS);
+        agentMapper = mock(SsResExtAgentMapper.class, CALLS_REAL_METHODS);
+        docMapper = mock(SsResExtDocMapper.class, CALLS_REAL_METHODS);
+        viewMapper = mock(SsResExtViewMapper.class, CALLS_REAL_METHODS);
+        objectMapper = mock(SsResExtObjectMapper.class, CALLS_REAL_METHODS);
+        skillMapper = mock(SsResExtSkillMapper.class, CALLS_REAL_METHODS);
+
+        toolKitService = new SsResExtToolKitService();
+        ReflectionTestUtils.setField(toolKitService, "ssResExtToolKitMapper", toolKitMapper);
+
+        mcpService = new SsResExtMcpService();
+        ReflectionTestUtils.setField(mcpService, "ssResExtMcpMapper", mcpMapper);
+
+        agentService = new SsResExtAgentService();
+        ReflectionTestUtils.setField(agentService, "ssResExtAgentMapper", agentMapper);
+
+        docService = new SsResExtDocService();
+        ReflectionTestUtils.setField(docService, "ssResExtDocMapper", docMapper);
+
+        viewService = new SsResExtViewService();
+        ReflectionTestUtils.setField(viewService, "ssResExtViewMapper", viewMapper);
+
+        objectService = new SsResExtObjectService();
+        ReflectionTestUtils.setField(objectService, "ssResExtObjectMapper", objectMapper);
+
+        skillService = new SsResExtSkillService();
+        ReflectionTestUtils.setField(skillService, "ssResExtSkillMapper", skillMapper);
+
+        appService = new DigitalEmployeeApplicationService();
+        ReflectionTestUtils.setField(appService, "ssResExtToolKitService", toolKitService);
+        ReflectionTestUtils.setField(appService, "ssResExtMcpService", mcpService);
+        ReflectionTestUtils.setField(appService, "ssResExtAgentService", agentService);
+        ReflectionTestUtils.setField(appService, "ssResExtDocService", docService);
+        ReflectionTestUtils.setField(appService, "ssResExtViewService", viewService);
+        ReflectionTestUtils.setField(appService, "ssResExtObjectService", objectService);
+        ReflectionTestUtils.setField(appService, "ssResExtSkillService", skillService);
+    }
+
+    // ---------------------- 1) Mapper 边界测试 ----------------------
+
+    @Test
+    @DisplayName("ToolKitMapper.findByIds: 空集合 → 不触发 SQL，返回空 List")
+    void toolkitMapper_findByIds_emptyCollection_returnsEmptyAndSkipsSql() {
+        List<SsResExtToolKit> result = toolKitMapper.findByIds(Collections.emptyList());
+
+        assertThat(result).isEmpty();
+        verify(toolKitMapper, never()).selectBatchIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("McpMapper.findByIds: null → 不触发 SQL，返回空 List")
+    void mcpMapper_findByIds_null_returnsEmptyAndSkipsSql() {
+        List<SsResExtMcp> result = mcpMapper.findByIds(null);
+
+        assertThat(result).isEmpty();
+        verify(mcpMapper, never()).selectBatchIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("AgentMapper.findByIds: 去重 → 委托 selectBatchIds")
+    void agentMapper_findByIds_dedupDelegatedToSelectBatchIds() {
+        Set<Long> dedup = new LinkedHashSet<>(Arrays.asList(1L, 2L, 1L, 3L, 2L));
+        SsResExtAgent a1 = new SsResExtAgent();
+        a1.setResourceId(1L);
+        SsResExtAgent a2 = new SsResExtAgent();
+        a2.setResourceId(2L);
+        SsResExtAgent a3 = new SsResExtAgent();
+        a3.setResourceId(3L);
+        when(agentMapper.selectBatchIds(dedup)).thenReturn(Arrays.asList(a1, a2, a3));
+
+        List<SsResExtAgent> result = agentMapper.findByIds(dedup);
+
+        assertThat(result).hasSize(3);
+        verify(agentMapper, times(1)).selectBatchIds(dedup);
+    }
+
+    @Test
+    @DisplayName("DocMapper.findByIds: 非空入参 → 委托 selectBatchIds")
+    void docMapper_findByIds_nonEmptyDelegatedToSelectBatchIds() {
+        List<Long> ids = Arrays.asList(10L, 20L);
+        SsResExtDoc d = new SsResExtDoc();
+        d.setResourceId(10L);
+        when(docMapper.selectBatchIds(ids)).thenReturn(Collections.singletonList(d));
+
+        List<SsResExtDoc> result = docMapper.findByIds(ids);
+
+        assertThat(result).hasSize(1);
+        verify(docMapper, times(1)).selectBatchIds(ids);
+    }
+
+    @Test
+    @DisplayName("ViewMapper.findByIds: 空集合 → 不触发 SQL")
+    void viewMapper_findByIds_emptySkipsSql() {
+        List<SsResExtView> result = viewMapper.findByIds(Collections.emptySet());
+
+        assertThat(result).isEmpty();
+        verify(viewMapper, never()).selectBatchIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("ObjectMapper.findByIds: 空集合 → 不触发 SQL")
+    void objectMapper_findByIds_emptySkipsSql() {
+        List<SsResExtObject> result = objectMapper.findByIds(Collections.emptyList());
+
+        assertThat(result).isEmpty();
+        verify(objectMapper, never()).selectBatchIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("SkillMapper.findByIds: null → 不触发 SQL")
+    void skillMapper_findByIds_nullSkipsSql() {
+        List<SsResExtSkill> result = skillMapper.findByIds(null);
+
+        assertThat(result).isEmpty();
+        verify(skillMapper, never()).selectBatchIds(anyCollection());
+    }
+
+    // ---------------------- 2) Service 包装方法测试 ----------------------
+
+    @Test
+    @DisplayName("ToolKitService.findByIds → Mapper.findByIds 单次调用")
+    void toolkitService_findByIds_delegatesToMapperOnce() {
+        List<Long> ids = Arrays.asList(1L, 2L, 3L);
+        doReturn(Collections.emptyList()).when(toolKitMapper).findByIds(ids);
+
+        List<SsResExtToolKit> result = toolKitService.findByIds(ids);
+
+        assertThat(result).isEmpty();
+        verify(toolKitMapper, times(1)).findByIds(ids);
+    }
+
+    @Test
+    @DisplayName("McpService.findByIds → Mapper.findByIds 单次调用（空集合）")
+    void mcpService_findByIds_emptyCollection_passesThrough() {
+        doReturn(Collections.emptyList()).when(mcpMapper).findByIds(Collections.emptyList());
+
+        List<SsResExtMcp> result = mcpService.findByIds(Collections.emptyList());
+
+        assertThat(result).isEmpty();
+        verify(mcpMapper, times(1)).findByIds(Collections.emptyList());
+    }
+
+    @Test
+    @DisplayName("ObjectService.findByIds → Mapper.findByIds 单次调用")
+    void objectService_findByIds_delegatesToMapperOnce() {
+        List<Long> ids = Arrays.asList(5L, 6L);
+        doReturn(Collections.emptyList()).when(objectMapper).findByIds(ids);
+
+        List<SsResExtObject> result = objectService.findByIds(ids);
+
+        assertThat(result).isEmpty();
+        verify(objectMapper, times(1)).findByIds(ids);
+    }
+
+    @Test
+    @DisplayName("SkillService.findByIds → Mapper.findByIds 单次调用")
+    void skillService_findByIds_delegatesToMapperOnce() {
+        List<Long> ids = Arrays.asList(7L, 8L, 9L, 10L);
+        doReturn(Collections.emptyList()).when(skillMapper).findByIds(ids);
+
+        List<SsResExtSkill> result = skillService.findByIds(ids);
+
+        assertThat(result).isEmpty();
+        verify(skillMapper, times(1)).findByIds(ids);
+    }
+
+    // ---------------------- 3) batchLoadTargetContent 集成测试 ----------------------
+
+    @Test
+    @DisplayName("batchLoadTargetContent(TOOLKIT, 3 ids) → ToolKit.findByIds 调用 1 次（而非 3 次循环 findById）")
+    void batchLoadTargetContent_toolkit_callsFindByIdsOnceNotFindById() {
+        List<Long> ids = Arrays.asList(101L, 102L, 103L);
+        SsResExtToolKit e1 = new SsResExtToolKit();
+        e1.setResourceId(101L);
+        e1.setTargetContent("{\"toolkit\":1}");
+        SsResExtToolKit e2 = new SsResExtToolKit();
+        e2.setResourceId(102L);
+        e2.setTargetContent("{\"toolkit\":2}");
+        SsResExtToolKit e3 = new SsResExtToolKit();
+        e3.setResourceId(103L);
+        // target_content 为空的资源不应进入返回 Map
+        when(toolKitMapper.findByIds(ids)).thenReturn(Arrays.asList(e1, e2, e3));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("TOOLKIT", ids);
+
+        assertThat(result).hasSize(2).containsEntry(101L, "{\"toolkit\":1}")
+            .containsEntry(102L, "{\"toolkit\":2}");
+        verify(toolKitMapper, times(1)).findByIds(ids);
+        // 关键断言:批量替换循环 findById, 确认未调用单条 selectById
+        verify(toolKitMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(KG_DOC, 4 ids) → Doc.findByIds 调用 1 次")
+    void batchLoadTargetContent_doc_callsFindByIdsOnceNotFindById() {
+        List<Long> ids = Arrays.asList(201L, 202L, 203L, 204L);
+        SsResExtDoc d1 = new SsResExtDoc();
+        d1.setResourceId(201L);
+        d1.setTargetContent("{\"kg\":\"doc1\"}");
+        SsResExtDoc d2 = new SsResExtDoc();
+        d2.setResourceId(202L);
+        d2.setTargetContent("{\"kg\":\"doc2\"}");
+        when(docMapper.findByIds(ids)).thenReturn(Arrays.asList(d1, d2));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("KG_DOC", ids);
+
+        assertThat(result).hasSize(2);
+        verify(docMapper, times(1)).findByIds(ids);
+        verify(docMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(空集合) → 早返回 Map.empty，不触发任何 mapper 调用")
+    void batchLoadTargetContent_emptyCollection_returnsEmptyImmediately() {
+        Map<Long, String> result = appService.batchLoadTargetContent("TOOLKIT", Collections.emptyList());
+
+        assertThat(result).isEmpty();
+        verify(toolKitMapper, never()).findByIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(null) → 早返回 Map.empty")
+    void batchLoadTargetContent_nullCollection_returnsEmptyImmediately() {
+        Map<Long, String> result = appService.batchLoadTargetContent("MCP", null);
+
+        assertThat(result).isEmpty();
+        verify(mcpMapper, never()).findByIds(anyCollection());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(去重 null/重复) → 仅入参非空且去重")
+    void batchLoadTargetContent_filtersNullAndDuplicates() {
+        Collection<Long> input = Arrays.asList(null, 301L, 301L, 302L, null);
+        SsResExtAgent a1 = new SsResExtAgent();
+        a1.setResourceId(301L);
+        a1.setTargetContent("{\"agent\":1}");
+        when(agentMapper.findByIds(anyCollection())).thenReturn(Collections.singletonList(a1));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("AGENT", input);
+
+        assertThat(result).hasSize(1).containsEntry(301L, "{\"agent\":1}");
+        // 验证传给 mapper 的集合已去重（去重后大小为 2）
+        org.mockito.ArgumentCaptor<Collection<Long>> captor =
+            org.mockito.ArgumentCaptor.forClass(Collection.class);
+        verify(agentMapper, times(1)).findByIds(captor.capture());
+        assertThat(new HashSet<>(captor.getValue())).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(TOOLKIT, mapper 抛异常) → 整体异常被 catch，返回空 Map 不影响调用方")
+    void batchLoadTargetContent_toolkitMapperThrows_returnsEmptyMapAndLogsWarn() {
+        List<Long> ids = Arrays.asList(401L, 402L);
+        when(toolKitMapper.findByIds(ids)).thenThrow(new RuntimeException("simulated DB failure"));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("TOOLKIT", ids);
+
+        assertThat(result).isEmpty();
+        verify(toolKitMapper, times(1)).findByIds(ids);
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(VIEW, mapper 返回空) → 返回空 Map")
+    void batchLoadTargetContent_viewEmptyResult_returnsEmptyMap() {
+        List<Long> ids = Arrays.asList(501L, 502L);
+        when(viewMapper.findByIds(ids)).thenReturn(Collections.emptyList());
+
+        Map<Long, String> result = appService.batchLoadTargetContent("VIEW", ids);
+
+        assertThat(result).isEmpty();
+        verify(viewMapper, times(1)).findByIds(ids);
+        verify(viewMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(OBJECT) → Mapper.findByIds 调用 1 次（替换原循环 findById）")
+    void batchLoadTargetContent_object_callsFindByIdsOnceNotFindById() {
+        List<Long> ids = Arrays.asList(601L, 602L);
+        SsResExtObject o = new SsResExtObject();
+        o.setResourceId(601L);
+        o.setTargetContent("{\"object\":1}");
+        when(objectMapper.findByIds(ids)).thenReturn(Collections.singletonList(o));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("OBJECT", ids);
+
+        assertThat(result).hasSize(1).containsEntry(601L, "{\"object\":1}");
+        verify(objectMapper, times(1)).findByIds(ids);
+        verify(objectMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(SKILL) → Mapper.findByIds 调用 1 次（替换原循环 findById）")
+    void batchLoadTargetContent_skill_callsFindByIdsOnceNotFindById() {
+        List<Long> ids = Arrays.asList(701L, 702L, 703L);
+        SsResExtSkill s = new SsResExtSkill();
+        s.setResourceId(702L);
+        s.setTargetContent("{\"skill\":2}");
+        when(skillMapper.findByIds(ids)).thenReturn(Collections.singletonList(s));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("SKILL", ids);
+
+        assertThat(result).hasSize(1).containsEntry(702L, "{\"skill\":2}");
+        verify(skillMapper, times(1)).findByIds(ids);
+        verify(skillMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("batchLoadTargetContent(MCP) → Mapper.findByIds 调用 1 次（替换原循环 findById）")
+    void batchLoadTargetContent_mcp_callsFindByIdsOnceNotFindById() {
+        List<Long> ids = Arrays.asList(801L, 802L);
+        SsResExtMcp m = new SsResExtMcp();
+        m.setResourceId(801L);
+        m.setTargetContent("{\"mcp\":1}");
+        when(mcpMapper.findByIds(ids)).thenReturn(Collections.singletonList(m));
+
+        Map<Long, String> result = appService.batchLoadTargetContent("MCP", ids);
+
+        assertThat(result).hasSize(1).containsEntry(801L, "{\"mcp\":1}");
+        verify(mcpMapper, times(1)).findByIds(ids);
+        verify(mcpMapper, never()).selectById(org.mockito.ArgumentMatchers.anyLong());
+    }
+}


### PR DESCRIPTION
> Part of #150 — Draft PR for issue tracker

## 范围

批量 `findByIdList` 替代循环 N+1 + 整页 target_content 预取 + 空白率门禁。

对应 Issue #150 子问题 **c** （N+1 与循环 findById，DB 压力过大）。

## 子问题概要

**c) N+1 与循环 `findById`，DB 压力过大**

- `resolveDigEmployeeJsonForRedisSync` (L1411-1427) `target_content` 为空时回退 `findDetailsById` (L1967-2019)，单次 7-10 SQL
- `syncRelatedResourceConfigJsonsToRedisQuietly` (L1527-1549) for 循环逐资源 `findById`
- D=10k, R=5, P(空白)=1.0 时总 SQL ≈ 130k，wall-clock ≈ 17-18 min

## 改动文件清单

| 文件 | 类型 | 改动 |
|------|------|------|
| `byclaw-be/src/main/java/com/iwhalecloud/byai/manager/application/service/digitemploy/DigitalEmployeeApplicationService.java` | 修改 | `syncRelatedResourceConfigJsonsToRedisQuietly` 用批量接口；`resolveDigEmployeeJsonForRedisSync` 增加空白跳过 |
| `byclaw-be/src/main/java/com/iwhalecloud/byai/manager/domain/resource/service/SsResourceService.java` | 既有 | `findByIdList` L436-443 直接复用 |
| 各 `SsResExtXxxService` | **待核实** | 是否都有 `findByIds` 批量接口（详见 §待核实清单） |
| CI 配置 | 修改 | `target_content` 空白率门禁（与 PR-1 的 `StartupTargetContentPreloader` 配套） |

## 详细设计要点

### 1. `syncRelatedResourceConfigJsonsToRedisQuietly` 重写

```java
// Before (current):
for (SsResource relResource : relResources) {
    String targetContent = loadRelatedResourceTargetContent(bizType, relResourceId); // 1 SQL per resource
    syncResourceConfigJsonToRedis(bizType, relResourceId, targetContent);
}

// After (proposed):
Map<String, List<Long>> bizTypeToIds = relResources.stream()
    .collect(groupingBy(SsResource::getResourceBizType, mapping(SsResource::getResourceId, toList())));
for (var entry : bizTypeToIds.entrySet()) {
    Map<Long, String> targetMap = batchLoadTargetContent(entry.getKey(), entry.getValue()); // 1 SQL per bizType
    for (var rel : entry.getValue().stream().map(id -> Map.entry(id, targetMap.get(id))).toList()) {
        syncResourceConfigJsonToRedis(entry.getKey(), rel.getKey(), rel.getValue());
    }
}
```

### 2. `target_content` 整页预取（PR-1 已铺基础）

```java
// 在每页 (B=1000) 内一次性拉取 target_content
Page<SsResExtDigEmployee> extsPage = ssResExtDigEmployeeMapper.selectBatchByResourceIds(resourceIds);
Map<Long, String> targetMap = extsPage.stream()
    .filter(ext -> ext.getTargetContent() != null && !ext.getTargetContent().isBlank())
    .collect(toMap(SsResExtDigEmployee::getResourceId, SsResExtDigEmployee::getTargetContent));

// 分组：有 target_content vs 空白
List<SsResource> withContent = ...;
List<SsResource> blankGroup = ...;

// 空白组整批跳过 + 记日志，不再逐资源判
if (!blankGroup.isEmpty()) {
    logger.warn("[target_content skip] {} resources in this page (rate={}%)",
        blankGroup.size(),
        100.0 * blankGroup.size() / pageSize);
}
```

### 3. `target_content` 空白跳过（**必须 c-4 预生成完成**）

- 开关 `byai.dig-employee.startup-sync.skip-blank-target-content` 默认 **`false`**（PR-1 引入）
- 开启条件：`blank_target_content_rate < 0.001`（空白率低于 0.1%）
- **CI 门禁**：上线前必须跑过 `StartupTargetContentPreloader`，指标必须达标
- 与 PR-1 同 PR-3 顺序：PR-1 上线 → 跑 c-4 → 验证 metric → 才允许 PR-3 开启开关

## 详细量化（D=10k, R=5, P=空白=1.0）

| 指标 | 优化前 | 优化后 | 提升 |
|------|--------|--------|------|
| 单资源 DB SQL（target_content 空白场景） | 7-10 | 0 | **消除** |
| 关联资源 SQL（R=5） | 5 (单条 findById) | 1 (批量) | 5x |
| D=10k, R=5, P=1.0 总 SQL | ~130k | ~5k（按 c-1 + c-3 全部应用） | **26x** |
| DB wall-clock | ~17 min | ~40 s | 25x |

## 待核实清单（需在 PR 开发前确认）

> Reviewer 已将以下项列入"待核实"，需要 PR-3 实施前先闭环：

| # | 待核实项 | 责任 |
|---|---------|------|
| 1 | `ssResExtToolKitService.findByIds` 是否存在 | byclaw-be owner |
| 2 | `ssResExtMcpService.findByIds` 是否存在 | byclaw-be owner |
| 3 | `ssResExtAgentService.findByIds` 是否存在 | byclaw-be owner |
| 4 | `ssResExtDocService.findByIds` 是否存在 | byclaw-be owner |
| 5 | `ssResExtViewService.findByIds` 是否存在 | byclaw-be owner |
| 6 | `ssResExtObjectService.findByIds` 是否存在 | byclaw-be owner |
| 7 | `ssResExtSkillService.findByIds` 是否存在 | byclaw-be owner |
| 8 | 若有缺失，本 PR 需先补齐（**禁止"先搞有的、缺的留 TODO"**） | PR-3 开发 |

## 配置项清单

| Key | 默认值 | 说明 |
|-----|--------|------|
| `byai.dig-employee.startup-sync.skip-blank-target-content` | `false` | 空白跳过（**前置条件：blank_target_content_rate < 0.1%**） |

## 验收标准

- [ ] D=10k, R=5, P(空白)=1.0 场景下 SQL 数 ≤ 10,000（vs 当前 ~130k）
- [ ] 批量接口覆盖率 100%（7 个 ext service `findByIds` 全齐）
- [ ] `target_content` 空白率指标暴露并 < 0.1%（不开关前条件；开开关后必须保持）
- [ ] 单元测试覆盖：`syncRelatedResourceConfigJsonsToRedisQuietly` 主路径 + 边界

## Reviewer 评审意见采纳

- ✅ 各 ext service 批量接口**全齐**才能进 PR（Reviewer 提示）
- ✅ 整页预取 SQL 单条字节数监控
- ✅ 跳过开关必须门禁 CI 验证空白率
- ✅ DB SQL 总数 metric 暴露

## 不在本 PR 范围

- Redis Pipeline（PR-1）
- 分布式锁（PR-2）
- DLQ（PR-4）
- 离线预生成脚本（PR-1 内同 commit 上线，**不**在本 PR）

## 相关文档

- Issue: https://github.com/beyonai/ByClaw/issues/150
- Reviewer Report: `/by/.sessions/10008243/evidence/issue-150-reviewer-report.md`
- PRD: `/by/.sessions/10008243/evidence/issue-150-prd.md`
