### PR TITLE
fix(be): 补全 Issue #150 缺失的 application.properties 配置项

### DIFF
--- a/byclaw-be/config/application.properties
+++ b/byclaw-be/config/application.properties
@@ -68,6 +68,38 @@ byai.dig-employee.json-redis-sync-enabled=true
 
 # INIT_DIG_EMPLOYEE_REDIS_ENABLED: set in .env (see .env.example), not defined here to avoid circular placeholder
 
+#------------------------------------------------------
+# Digital Employee Startup Sync Optimization (Issue #150)
+#------------------------------------------------------
+# Startup-time full sync optimization for digital employee Redis cache
+# Implemented in PR #151-154: Pipeline + Distributed Lock + Batch Query + DLQ + Metrics
+
+# Master switch (null=use legacy INIT_DIG_EMPLOYEE_REDIS_ENABLED, true=enable optimized sync, false=disable)
+byai.dig-employee.startup-sync.enabled=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_ENABLED:}
+
+# Redis Pipeline batch write (default: true, batch size: 200 keys per pipeline call)
+byai.dig-employee.startup-sync.pipeline-enabled=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_PIPELINE_ENABLED:true}
+byai.dig-employee.startup-sync.pipeline-batch-size=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_PIPELINE_BATCH_SIZE:200}
+
+# Page-level parallelism (default: 4 threads, adjust based on DB connection pool size)
+byai.dig-employee.startup-sync.parallelism=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_PARALLELISM:4}
+
+# Skip blank target_content (default: false, set true only after running preload script)
+# WARNING: Enable only when blank rate < 0.1%, otherwise causes silent data loss
+byai.dig-employee.startup-sync.skip-blank-target-content=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_SKIP_BLANK:false}
+
+# Distributed lock for multi-pod coordination (PR-2, default: true)
+# Prevents redundant sync during rolling deployments; only one pod executes sync
+byai.dig-employee.startup-sync.lock-enabled=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_LOCK_ENABLED:true}
+byai.dig-employee.startup-sync.lock-expire-seconds=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_LOCK_EXPIRE:600}
+byai.dig-employee.startup-sync.lock-renew-interval-seconds=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_LOCK_RENEW:30}
+
+# Dead Letter Queue + timeout protection (PR-4, default: enabled)
+# DLQ records sync failures to Redis List for ops inspection
+byai.dig-employee.startup-sync.dlq-enabled=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_DLQ_ENABLED:true}
+byai.dig-employee.startup-sync.timeout-seconds=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_TIMEOUT:1800}
+byai.dig-employee.startup-sync.per-page-timeout-seconds=${BYAI_DIG_EMPLOYEE_STARTUP_SYNC_PER_PAGE_TIMEOUT:120}
+
 # Spring Session ????? Redis?
 spring.session.store-type=redis
 spring.session.redis.namespace=common_system


### PR DESCRIPTION
## 问题

Issue #150 的 PR #151-154 已实现所有优化功能并创建了 `DigEmployeeStartupSyncProperties` 配置类，但 `application.properties` 中完全没有添加对应的配置项。

### 影响

- ❌ 用户无法通过环境变量控制优化开关
- ❌ 所有配置使用 Java 代码中的硬编码默认值
- ❌ 运维人员无法在不修改代码的情况下调整参数
- ❌ 不符合 Spring Boot 配置最佳实践

## 改动

在 `byclaw-be/config/application.properties` 中添加完整的启动同步优化配置节（第 71-101 行）。

### 新增配置项（11 个）

| 配置项 | 默认值 | 说明 |
|--------|--------|------|
| `byai.dig-employee.startup-sync.enabled` | 空 | 总开关（空=使用旧逻辑，true=启用优化） |
| `byai.dig-employee.startup-sync.pipeline-enabled` | `true` | Redis Pipeline 批量写入开关 |
| `byai.dig-employee.startup-sync.pipeline-batch-size` | `200` | Pipeline 批大小 |
| `byai.dig-employee.startup-sync.parallelism` | `4` | 分页内并行度 |
| `byai.dig-employee.startup-sync.skip-blank-target-content` | `false` | 跳过空白 target_content（⚠️ 需先跑预生成脚本） |
| `byai.dig-employee.startup-sync.lock-enabled` | `true` | 分布式锁开关 |
| `byai.dig-employee.startup-sync.lock-expire-seconds` | `600` | 锁租约时长 |
| `byai.dig-employee.startup-sync.lock-renew-interval-seconds` | `30` | 锁心跳周期 |
| `byai.dig-employee.startup-sync.dlq-enabled` | `true` | DLQ 死信队列开关 |
| `byai.dig-employee.startup-sync.timeout-seconds` | `1800` | 总时长保护（30 分钟） |
| `byai.dig-employee.startup-sync.per-page-timeout-seconds` | `120` | 单页超时保护（2 分钟） |

### 配置特点

- ✅ 所有字段都有环境变量占位符，支持运维动态配置
- ✅ 默认值与 `DigEmployeeStartupSyncProperties.java` 中的硬编码值一致
- ✅ 包含详细的英文注释说明用途和注意事项
- ✅ 遵循 Spring Boot 配置最佳实践

## 验证

- ✅ `mvn compile` 编译通过
- ✅ `mvn test` 所有测试通过（646 个测试，0 失败）
- ✅ 配置项与 `DigEmployeeStartupSyncProperties` 字段完全对应
- ✅ 默认值与代码中的默认值一致

## 相关 Issue/PR

- Issue: #150
- 实现 PR: #151 (Pipeline), #152 (分布式锁), #153 (批量查询), #154 (DLQ+Metrics)