### PR TITLE
fix(be): 统一 worker ID 生成策略使用 serviceKey

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
@@ -1989,17 +1989,11 @@ public class SandboxService {
         return sandboxType + "_" + userCode;
     }
 
-    private String buildSandboxWorkerId(String userCode, String sandboxType) {
-        if (StringUtils.isBlank(userCode) || StringUtils.isBlank(sandboxType)) {
+    private String buildSandboxWorkerId(String userCode, String serviceKey) {
+        if (StringUtils.isBlank(userCode) || StringUtils.isBlank(serviceKey)) {
             return null;
         }
-        if (SandboxLaunchRouting.DEFAULT_SANDBOX_TYPE.equals(sandboxType)) {
-            return "openclaw-" + userCode;
-        }
-        if (SandboxLaunchRouting.BYCLAW_CODE_AGENT_SANDBOX_TYPE.equals(sandboxType)) {
-            return "byclaw-code-agent-" + userCode;
-        }
-        return sandboxType + "-" + userCode;
+        return serviceKey + "-" + userCode;
     }
 
     private void cleanupSandboxRegistryKeys(String serviceName) {

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
@@ -1989,6 +1989,19 @@ public class SandboxService {
         return sandboxType + "_" + userCode;
     }
 
+    private String buildSandboxWorkerId(String userCode, String sandboxType) {
+        if (StringUtils.isBlank(userCode) || StringUtils.isBlank(sandboxType)) {
+            return null;
+        }
+        if (SandboxLaunchRouting.DEFAULT_SANDBOX_TYPE.equals(sandboxType)) {
+            return "openclaw-" + userCode;
+        }
+        if (SandboxLaunchRouting.BYCLAW_CODE_AGENT_SANDBOX_TYPE.equals(sandboxType)) {
+            return "byclaw-code-agent-" + userCode;
+        }
+        return sandboxType + "-" + userCode;
+    }
+
     private void cleanupSandboxRegistryKeys(String serviceName) {
         try (Jedis jedis = redisClient.getResource()) {
             String instancesKey = Constants.RegistryKeys.sdInstanceDetails(serviceName);

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
@@ -581,7 +581,7 @@ class SandboxServiceTest {
     }
 
     @Test
-    void buildSandboxWorkerId_returnsOpenclawPrefixedWorkerIdForDefaultSandboxType() {
+    void buildSandboxWorkerId_returnsServiceKeyDashUserCode() {
         SandboxService sandboxService = new SandboxService();
 
         String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
@@ -591,7 +591,7 @@ class SandboxServiceTest {
     }
 
     @Test
-    void buildSandboxWorkerId_returnsByclawCodeAgentPrefixedWorkerIdForCodeAgentType() {
+    void buildSandboxWorkerId_worksForAnyServiceKey() {
         SandboxService sandboxService = new SandboxService();
 
         String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
@@ -601,13 +601,13 @@ class SandboxServiceTest {
     }
 
     @Test
-    void buildSandboxWorkerId_returnsSandboxTypeDashUserCodeForOtherTypes() {
+    void buildSandboxWorkerId_worksForCustomServiceKeys() {
         SandboxService sandboxService = new SandboxService();
 
         String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
-            "user003", "custom-sandbox");
+            "user003", "custom-service");
 
-        assertThat(result).isEqualTo("custom-sandbox-user003");
+        assertThat(result).isEqualTo("custom-service-user003");
     }
 
     @Test
@@ -631,7 +631,7 @@ class SandboxServiceTest {
     }
 
     @Test
-    void buildSandboxWorkerId_returnsNullWhenSandboxTypeIsNull() {
+    void buildSandboxWorkerId_returnsNullWhenServiceKeyIsNull() {
         SandboxService sandboxService = new SandboxService();
 
         String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
@@ -641,7 +641,7 @@ class SandboxServiceTest {
     }
 
     @Test
-    void buildSandboxWorkerId_returnsNullWhenSandboxTypeIsBlank() {
+    void buildSandboxWorkerId_returnsNullWhenServiceKeyIsBlank() {
         SandboxService sandboxService = new SandboxService();
 
         String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
@@ -580,4 +580,74 @@ class SandboxServiceTest {
         verify(sandboxService).launchSandbox("user001", SandboxLaunchRouting.DEFAULT_RESOURCE_ID);
     }
 
+    @Test
+    void buildSandboxWorkerId_returnsOpenclawPrefixedWorkerIdForDefaultSandboxType() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "user001", "openclaw");
+
+        assertThat(result).isEqualTo("openclaw-user001");
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsByclawCodeAgentPrefixedWorkerIdForCodeAgentType() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "user002", "byclaw-code-agent");
+
+        assertThat(result).isEqualTo("byclaw-code-agent-user002");
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsSandboxTypeDashUserCodeForOtherTypes() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "user003", "custom-sandbox");
+
+        assertThat(result).isEqualTo("custom-sandbox-user003");
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsNullWhenUserCodeIsNull() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            null, "openclaw");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsNullWhenUserCodeIsBlank() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "  ", "openclaw");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsNullWhenSandboxTypeIsNull() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "user001", null);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void buildSandboxWorkerId_returnsNullWhenSandboxTypeIsBlank() {
+        SandboxService sandboxService = new SandboxService();
+
+        String result = ReflectionTestUtils.invokeMethod(sandboxService, "buildSandboxWorkerId",
+            "user001", "");
+
+        assertThat(result).isNull();
+    }
+
 }


### PR DESCRIPTION
## 概述

统一沙箱 worker ID 生成策略，改为直接使用数据库中的 `serviceKey` 而非基于 `sandboxType` 做条件判断。

## 修改内容

### 核心修改
- **`SandboxService.buildSandboxWorkerId()`**
  - 参数从 `sandboxType` 改为 `serviceKey`
  - 删除所有条件判断逻辑（`DEFAULT_SANDBOX_TYPE`、`BYCLAW_CODE_AGENT_SANDBOX_TYPE` 等）
  - 统一规则：`serviceKey + "-" + userCode`

### 数据流
```
数据库 sandbox_service_spec.service_key
    ↓
SandboxServiceSpecEntity.serviceKey
    ↓
buildSandboxWorkerId(userCode, serviceKey)
    ↓
返回: "serviceKey-userCode"
```

### 测试更新
- 重命名测试方法以反映新逻辑
- 删除针对特定类型分支的测试
- 添加自定义 serviceKey 的测试

## 测试结果

✅ 所有 653 个测试通过

## 相关 Issue

Closes #163