### PR TITLE
feat(exe): support BYAI_WORKER_ID env var in byai-channel worker

### DIFF
--- a/byclaw-exe/extensions/byai-channel/src/sdk-app.ts
+++ b/byclaw-exe/extensions/byai-channel/src/sdk-app.ts
@@ -355,7 +355,8 @@ export class ByaiSdkApp {
 
     debug?.(`[${this.account.accountId}] byai-channel usercode: ${userCode}`);
 
-    const workerId = `byai-channel-worker-${userCode}-${Math.random().toString(16).slice(2, 6)}`;
+    // Use injected worker_id if available; otherwise fall back to deterministic id for backward compatibility
+    const workerId = process.env.BYAI_WORKER_ID || `byai-channel-worker-${userCode}`;
     const agentTypes = [`BYCLAW_EXE_${userCode}`];
 
     const registry = new WorkerRegistry(redis);


### PR DESCRIPTION
## 概述

byai-channel 支持通过 `BYAI_WORKER_ID` 环境变量接收确定性的 worker_id。

## 修改内容

修改 `byclaw-exe/extensions/byai-channel/src/sdk-app.ts`：

- 优先使用环境变量 `BYAI_WORKER_ID`（由后端沙箱启动时注入）
- fallback 为 `byai-channel-worker-{userCode}`（移除了随机后缀，与统一规则对齐）

## 为什么

Issue #157 修复沙箱释放后对话框假死问题，核心修复是统一 worker_id 生成规则（`serviceKey-userCode`），使后端在释放沙箱时能精确清理 Worker Registry 的 Redis key。

byai-channel 原来使用随机后缀，导致后端无法预测 worker_id 进行清理。

Refs #157