### PR TITLE
feat(be): inject BYAI_WORKER_ID on launch and cleanup worker registry on release

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxService.java
@@ -366,6 +366,7 @@ public class SandboxService {
                 incrementVersions(existingRecord, true);
                 sandboxMetadataCache.evict(existingRecord.getUserCode(), existingRecord.getSandboxType());
                 unregisterSandboxEndpoint(existingRecord.getUserCode(), existingRecord.getSandboxType());
+                cleanupWorkerRegistryForSandbox(existingRecord);
                 LOGGER.warn("远端沙箱退出，已清理远端并终结旧沙箱记录：{}", sandboxRef(existingRecord));
             }
 
@@ -609,7 +610,17 @@ public class SandboxService {
         SandboxLeasePolicy leasePolicy = resolveDefaultLeasePolicy();
         Integer autoRelease = leasePolicy == SandboxLeasePolicy.REMOTE_AUTO_EXPIRE
             ? AUTO_RELEASE_REMOTE : AUTO_RELEASE_MANUAL;
-        request.setEnvs(launchContext.getEnvs());
+        // Inject deterministic worker_id for by-framework worker registry alignment
+        String workerId = buildSandboxWorkerId(userCode, launchContext.getSandboxType());
+        Map<String, String> envs = launchContext.getEnvs() != null
+            ? new LinkedHashMap<>(launchContext.getEnvs())
+            : new LinkedHashMap<>();
+        if (StringUtils.isNotBlank(workerId)) {
+            envs.put("BYAI_WORKER_ID", workerId);
+            LOGGER.debug("Injecting BYAI_WORKER_ID for sandbox launch: userCode={}, sandboxType={}, workerId={}",
+                userCode, launchContext.getSandboxType(), workerId);
+        }
+        request.setEnvs(envs);
         request.setUserInfo(launchContext.getUserInfo());
         request.setSkipReusableSandbox(skipReusableSandbox);
         String gatewayToken = launchContext.getGatewayToken();
@@ -1816,6 +1827,7 @@ public class SandboxService {
         incrementVersions(record, true);
         sandboxMetadataCache.evict(record.getUserCode(), record.getSandboxType());
         unregisterSandboxEndpoint(record.getUserCode(), record.getSandboxType());
+        cleanupWorkerRegistryForSandbox(record);
         LOGGER.info("沙箱释放完成：{}，releaseReason：{}", sandboxRef(record), releaseReason);
     }
 
@@ -1994,6 +2006,31 @@ public class SandboxService {
             return null;
         }
         return serviceKey + "-" + userCode;
+    }
+
+    private void cleanupWorkerRegistryForSandbox(SsSandboxRecord record) {
+        if (record == null) {
+            return;
+        }
+        String workerId = buildSandboxWorkerId(record.getUserCode(), record.getSandboxType());
+        if (StringUtils.isBlank(workerId)) {
+            LOGGER.debug("Skipping worker registry cleanup: cannot build worker_id for sandbox {}", sandboxRef(record));
+            return;
+        }
+        try {
+            gatewayWorkerRegistry.markWorkerInactive(workerId);
+            LOGGER.info("Cleaned up worker_online_lease on sandbox release: workerId={}, sandbox={}", workerId, sandboxRef(record));
+        }
+        catch (Exception e) {
+            LOGGER.error("Failed to mark worker inactive on sandbox release: workerId={}, sandbox={}", workerId, sandboxRef(record), e);
+        }
+        try {
+            gatewayWorkerRegistry.unregisterWorkerMembership(workerId);
+            LOGGER.info("Cleaned up worker membership on sandbox release: workerId={}, sandbox={}", workerId, sandboxRef(record));
+        }
+        catch (Exception e) {
+            LOGGER.error("Failed to unregister worker membership on sandbox release: workerId={}, sandbox={}", workerId, sandboxRef(record), e);
+        }
     }
 
     private void cleanupSandboxRegistryKeys(String serviceName) {

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/service/SandboxServiceTest.java
@@ -650,4 +650,91 @@ class SandboxServiceTest {
         assertThat(result).isNull();
     }
 
+    @Test
+    void doLaunchSandbox_injectsByaiWorkerIdIntoEnvs() {
+        SandboxLaunchContextFactory sandboxLaunchContextFactory = mock(SandboxLaunchContextFactory.class);
+        SsSandboxRecordMapper sandboxRecordMapper = mock(SsSandboxRecordMapper.class);
+        SandboxLifecycleFacade sandboxLifecycleFacade = mock(SandboxLifecycleFacade.class);
+        SandboxMetadataCache sandboxMetadataCache = mock(SandboxMetadataCache.class);
+        com.iwhalecloud.byai.state.domain.sys.service.ByaiSystemConfigService systemConfigService =
+            mock(com.iwhalecloud.byai.state.domain.sys.service.ByaiSystemConfigService.class);
+        SandboxService sandboxService = new SandboxService();
+        ReflectionTestUtils.setField(sandboxService, "sandboxLaunchContextFactory", sandboxLaunchContextFactory);
+        ReflectionTestUtils.setField(sandboxService, "sandboxRecordMapper", sandboxRecordMapper);
+        ReflectionTestUtils.setField(sandboxService, "sandboxLifecycleFacade", sandboxLifecycleFacade);
+        ReflectionTestUtils.setField(sandboxService, "sandboxMetadataCache", sandboxMetadataCache);
+        ReflectionTestUtils.setField(sandboxService, "byaiSystemConfigService", systemConfigService);
+
+        SandboxLaunchRouting routing = new SandboxLaunchRouting("openclaw",
+            SandboxLaunchRouting.DEFAULT_RESOURCE_ID);
+        Map<String, String> envs = new java.util.HashMap<>();
+        envs.put("MODEL_BASE_URL", "https://model.example");
+        SandboxLaunchContext launchContext = new SandboxLaunchContext("openclaw", envs, Map.of(), "gateway-token");
+        when(sandboxLaunchContextFactory.buildContext("user001", 100L, "openclaw")).thenReturn(launchContext);
+        doAnswer(invocation -> {
+            SsSandboxRecord record = invocation.getArgument(0);
+            record.setId(99L);
+            return 1;
+        }).when(sandboxRecordMapper).insert(any(SsSandboxRecord.class));
+
+        ArgumentCaptor<com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest> requestCaptor =
+            ArgumentCaptor.forClass(com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest.class);
+        SandboxLaunchData launchData = new SandboxLaunchData();
+        launchData.setSandboxId("sandbox-1");
+        launchData.setEndpoint("http://host/proxy/18789/chat?token=gateway-token");
+        when(sandboxLifecycleFacade.launchSandbox(requestCaptor.capture())).thenReturn(SandboxResponse.success(launchData));
+        when(sandboxRecordMapper.updateLaunchSuccess(eq(99L), eq("sandbox-1"), any(), eq("gateway-token"),
+            any(), any(), any(), any(), any(), eq(0))).thenReturn(1);
+
+        ReflectionTestUtils.invokeMethod(sandboxService, "doLaunchSandbox",
+            "user001", 100L, routing);
+
+        com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest captured = requestCaptor.getValue();
+        assertThat(captured.getEnvs())
+            .containsEntry("BYAI_WORKER_ID", "openclaw-user001")
+            .containsEntry("MODEL_BASE_URL", "https://model.example");
+    }
+
+    @Test
+    void doLaunchSandbox_doesNotInjectByaiWorkerIdWhenUserCodeIsBlank() {
+        SandboxLaunchContextFactory sandboxLaunchContextFactory = mock(SandboxLaunchContextFactory.class);
+        SsSandboxRecordMapper sandboxRecordMapper = mock(SsSandboxRecordMapper.class);
+        SandboxLifecycleFacade sandboxLifecycleFacade = mock(SandboxLifecycleFacade.class);
+        SandboxMetadataCache sandboxMetadataCache = mock(SandboxMetadataCache.class);
+        com.iwhalecloud.byai.state.domain.sys.service.ByaiSystemConfigService systemConfigService =
+            mock(com.iwhalecloud.byai.state.domain.sys.service.ByaiSystemConfigService.class);
+        SandboxService sandboxService = new SandboxService();
+        ReflectionTestUtils.setField(sandboxService, "sandboxLaunchContextFactory", sandboxLaunchContextFactory);
+        ReflectionTestUtils.setField(sandboxService, "sandboxRecordMapper", sandboxRecordMapper);
+        ReflectionTestUtils.setField(sandboxService, "sandboxLifecycleFacade", sandboxLifecycleFacade);
+        ReflectionTestUtils.setField(sandboxService, "sandboxMetadataCache", sandboxMetadataCache);
+        ReflectionTestUtils.setField(sandboxService, "byaiSystemConfigService", systemConfigService);
+
+        // Use blank userCode so buildSandboxWorkerId returns null
+        SandboxLaunchRouting routing = new SandboxLaunchRouting("openclaw",
+            SandboxLaunchRouting.DEFAULT_RESOURCE_ID);
+        SandboxLaunchContext launchContext = new SandboxLaunchContext("openclaw", null, Map.of(), "gateway-token");
+        when(sandboxLaunchContextFactory.buildContext("", 100L, "openclaw")).thenReturn(launchContext);
+        doAnswer(invocation -> {
+            SsSandboxRecord record = invocation.getArgument(0);
+            record.setId(99L);
+            return 1;
+        }).when(sandboxRecordMapper).insert(any(SsSandboxRecord.class));
+
+        ArgumentCaptor<com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest> requestCaptor =
+            ArgumentCaptor.forClass(com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest.class);
+        SandboxLaunchData launchData = new SandboxLaunchData();
+        launchData.setSandboxId("sandbox-2");
+        launchData.setEndpoint("http://host/proxy/18789/chat?token=gateway-token");
+        when(sandboxLifecycleFacade.launchSandbox(requestCaptor.capture())).thenReturn(SandboxResponse.success(launchData));
+        when(sandboxRecordMapper.updateLaunchSuccess(eq(99L), eq("sandbox-2"), any(), eq("gateway-token"),
+            any(), any(), any(), any(), any(), eq(0))).thenReturn(1);
+
+        ReflectionTestUtils.invokeMethod(sandboxService, "doLaunchSandbox",
+            "", 100L, routing);
+
+        com.iwhalecloud.byai.common.feign.request.sandbox.SandboxLaunchRequest captured = requestCaptor.getValue();
+        assertThat(captured.getEnvs()).doesNotContainKey("BYAI_WORKER_ID");
+    }
+
 }


### PR DESCRIPTION
## 概述

实施 Issue #157 的两个核心后端改动，解决沙箱释放后对话框假死 ~30s 的问题。

## 修改内容

### #165 — 沙箱启动时注入 BYAI_WORKER_ID 环境变量

`SandboxService.doLaunchSandbox()` 中：
- 调用 `buildSandboxWorkerId(userCode, serviceKey)` 生成确定性 worker_id
- 将 `BYAI_WORKER_ID=serviceKey-userCode` 注入沙箱环境变量
- 保留原有 envs，null 时创建新 map

### #166 — 沙箱释放/重启时清理 Worker Registry

新增 `cleanupWorkerRegistryForSandbox(SsSandboxRecord record)`：
- 调用 `markWorkerInactive(workerId)` — 清除 30s TTL 的心跳租约
- 调用 `unregisterWorkerMembership(workerId)` — 清除反向索引等 3 类 key
- Best-effort：每步独立 try-catch，失败只记录日志不传播

挂载点：
- `doRemoveSandbox()` 末尾（手动释放 + 超时释放）
- `restartSandboxAfterRemoteExit()` 清理链末尾

## 测试

✅ 25 个 SandboxServiceTest 全部通过

## 相关

- Closes #165
- Closes #166
- Refs #157
- 配合 PR #169（byai-channel 适配）共同修复 #157