### PR TITLE
fix(be): inject BYAI_WORKER_ID as system env var bypassing spec filter

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/runtime/StandardSandboxLifecycleService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/runtime/StandardSandboxLifecycleService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -122,6 +123,7 @@ public class StandardSandboxLifecycleService implements SandboxLifecycleFacade {
                 userCode, sandboxType, launchRequest.getEnvs(), launchRequest.getUserInfo(), spec);
             String idempotencyKey = buildIdempotencyKey(userCode, sandboxType, launchRequest.getMetadata());
             mergeLaunchMetadata(request, launchRequest.getMetadata());
+            mergeSystemEnvs(request, launchRequest.getEnvs());
 
             Optional<SandboxRuntimeInstance> reusable = Boolean.TRUE.equals(launchRequest.getSkipReusableSandbox())
                 ? Optional.empty()
@@ -334,6 +336,28 @@ public class StandardSandboxLifecycleService implements SandboxLifecycleFacade {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to serialize SandboxInfo", e);
         }
+    }
+
+    /**
+     * Merge system-level env vars from launchEnvs into the CreateSandboxRequest.
+     * System env vars (e.g. BYAI_WORKER_ID) are injected for all containers regardless of spec declarations.
+     */
+    private static final Set<String> SYSTEM_ENV_KEYS = java.util.Set.of("BYAI_WORKER_ID");
+
+    private static void mergeSystemEnvs(CreateSandboxRequest request, Map<String, String> launchEnvs) {
+        if (request == null || launchEnvs == null || launchEnvs.isEmpty()) {
+            return;
+        }
+        Map<String, String> env = request.getEnv() != null
+            ? new LinkedHashMap<>(request.getEnv())
+            : new LinkedHashMap<>();
+        for (String key : SYSTEM_ENV_KEYS) {
+            String value = launchEnvs.get(key);
+            if (value != null && !value.isBlank()) {
+                env.put(key, value);
+            }
+        }
+        request.setEnv(env.isEmpty() ? null : env);
     }
 
     private static void mergeLaunchMetadata(CreateSandboxRequest request, Map<String, String> launchMetadata) {


### PR DESCRIPTION
## 问题

PR #170 的修复不生效：`BYAI_WORKER_ID` 加入了 `SandboxLaunchRequest.envs`，但 `GenericSandboxSpecProcessor.resolveSpecEnv()` 只透传 `sandbox_service_spec` 中**声明的** env key，`envs` 仅用作模板渲染上下文，不会直接注入容器。

## 修复

在 `StandardSandboxLifecycleService.createSandbox()` 中，`buildCreateRequest()` 完成后追加调用 `mergeSystemEnvs()`，将 `BYAI_WORKER_ID` 直接写入已构建的 `CreateSandboxRequest.env`，绕过 spec 过滤。

`SYSTEM_ENV_KEYS = {"BYAI_WORKER_ID"}` 是一个白名单，所有容器都会强制注入这些系统级环境变量。

## 为什么这样设计

`BYAI_WORKER_ID` 是框架级的系统变量，所有沙箱容器都必须携带，不应要求每个 `sandbox_service_spec` 单独声明。

## 测试

✅ 29 个测试全部通过（StandardSandboxLifecycleServiceTest + SandboxServiceTest）

Refs #157, #165