### PR TITLE
feat: Add OpenClaw sandbox status indicator in user config area

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
@@ -210,6 +210,12 @@ public class SandboxController {
                 if (sandboxType != null && !sandboxType.equalsIgnoreCase(sandbox.getSandboxType())) {
                     continue;
                 }
+
+                // 查询数据库记录获取完整状态
+                SsSandboxRecord record = sandboxRecordMapper.selectRunningByUserAndResource(
+                    userCode, sandbox.getSandboxType(), sandbox.getResourceId()
+                );
+
                 Map<String, Object> result = new HashMap<>();
                 result.put("userCode", userCode);
                 result.put("sandboxType", sandbox.getSandboxType());
@@ -217,6 +223,7 @@ public class SandboxController {
                 result.put("endpoints", sandbox.getEndpoints());
                 result.put("instanceEndpoints", sandbox.getInstanceEndpoints());
                 result.put("token", sandbox.getGatewayToken());
+                result.put("status", record != null ? record.getStatus() : "UNKNOWN");
                 data.add(result);
             }
         }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
@@ -212,8 +212,8 @@ public class SandboxController {
                 }
 
                 // 查询数据库记录获取完整状态
-                SsSandboxRecord record = sandboxRecordMapper.selectRunningByUserAndResource(
-                    userCode, sandbox.getSandboxType(), sandbox.getResourceId()
+                SsSandboxRecord record = sandboxRecordMapper.selectLatestBySandboxId(
+                    userCode, sandbox.getSandboxType(), sandbox.getSandboxId()
                 );
 
                 Map<String, Object> result = new HashMap<>();

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxControllerTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxControllerTest.java
@@ -30,14 +30,23 @@ class SandboxControllerTest {
     @Test
     void getSandboxInfo_returnsGatewayToken() {
         SandboxService sandboxService = mock(SandboxService.class);
+        SsSandboxRecordMapper sandboxRecordMapper = mock(SsSandboxRecordMapper.class);
         SandboxController controller = new SandboxController();
         ReflectionTestUtils.setField(controller, "sandboxService", sandboxService);
+        ReflectionTestUtils.setField(controller, "sandboxRecordMapper", sandboxRecordMapper);
+
         when(sandboxService.sandboxInfo("user001")).thenReturn(List.of(SandboxInfo.builder()
             .sandboxId("sandbox-1")
             .sandboxType("openclaw")
             .endpoints(List.of("http://host/proxy/18789/chat?token=0123456789abcdef0123456789abcdef"))
             .gatewayToken("0123456789abcdef0123456789abcdef")
             .build()));
+
+        // Mock database record to return RUNNING status
+        SsSandboxRecord record = new SsSandboxRecord();
+        record.setStatus("RUNNING");
+        when(sandboxRecordMapper.selectLatestBySandboxId("user001", "openclaw", "sandbox-1"))
+            .thenReturn(record);
 
         ResponseUtil response = controller.getSandboxIdByUserCode(Map.of("userCode", "user001"));
 
@@ -47,6 +56,7 @@ class SandboxControllerTest {
         assertThat(data).hasSize(1);
         assertThat(data.get(0))
             .containsEntry("token", "0123456789abcdef0123456789abcdef")
+            .containsEntry("status", "RUNNING")
             .doesNotContainKey("gatewayToken");
     }
 

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/index.tsx
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/index.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Dropdown, Tooltip, message } from 'antd';
+import type { MenuProps } from 'antd';
+import { useIntl } from '@umijs/max';
+import classNames from 'classnames';
+import useSandboxStatus from './useSandboxStatus';
+import styles from './styles.module.less';
+
+interface SandboxStatusIndicatorProps {
+  userCode: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const SandboxStatusIndicator: React.FC<SandboxStatusIndicatorProps> = ({ userCode, className, style }) => {
+  const intl = useIntl();
+  const { status, refetch, restartSandbox } = useSandboxStatus(userCode);
+  const [isRestarting, setIsRestarting] = useState(false);
+
+  const handleRestart = async () => {
+    try {
+      setIsRestarting(true);
+      await restartSandbox();
+      message.success(intl.formatMessage({ id: 'sandbox.restart.success' }));
+      refetch();
+    } catch (error) {
+      message.error(intl.formatMessage({ id: 'sandbox.restart.failed' }));
+    } finally {
+      setIsRestarting(false);
+    }
+  };
+
+  const menuItems: MenuProps['items'] = [
+    {
+      key: 'restart',
+      label: intl.formatMessage({ id: 'sandbox.action.restart' }),
+      onClick: handleRestart,
+      disabled: isRestarting,
+    },
+  ];
+
+  const getStatusText = () => {
+    switch (status) {
+      case 'running':
+        return intl.formatMessage({ id: 'sandbox.status.running' });
+      case 'transitioning':
+        return intl.formatMessage({ id: 'sandbox.status.transitioning' });
+      case 'stopped':
+        return intl.formatMessage({ id: 'sandbox.status.stopped' });
+      default:
+        return '';
+    }
+  };
+
+  const statusDotClass = classNames(styles.statusDot, {
+    [styles.running]: status === 'running',
+    [styles.transitioning]: status === 'transitioning',
+    [styles.stopped]: status === 'stopped',
+  });
+
+  return (
+    <Dropdown menu={{ items: menuItems }} placement="topRight" trigger={['click']}>
+      <Tooltip placement="right" title={getStatusText()}>
+        <div className={classNames(styles.sandboxStatusWrap, className)} style={style}>
+          <div className={statusDotClass} />
+        </div>
+      </Tooltip>
+    </Dropdown>
+  );
+};
+
+export default SandboxStatusIndicator;

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/styles.module.less
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/styles.module.less
@@ -1,0 +1,75 @@
+.sandboxStatusWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  transition: all 0.3s;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+    border-radius: 4px;
+  }
+}
+
+.statusDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  position: relative;
+
+  // 呼吸动画
+  &::before {
+    content: '';
+    position: absolute;
+    top: -2px;
+    left: -2px;
+    right: -2px;
+    bottom: -2px;
+    border-radius: 50%;
+    animation: pulse 2s ease-in-out infinite;
+  }
+}
+
+// 绿色 - 运行中
+.running {
+  background-color: #52c41a;
+  box-shadow: 0 0 8px rgba(82, 196, 26, 0.6);
+
+  &::before {
+    background-color: rgba(82, 196, 26, 0.3);
+  }
+}
+
+// 黄色 - 启动/停止中
+.transitioning {
+  background-color: #faad14;
+  box-shadow: 0 0 8px rgba(250, 173, 20, 0.6);
+
+  &::before {
+    background-color: rgba(250, 173, 20, 0.3);
+  }
+}
+
+// 红色 - 已停止
+.stopped {
+  background-color: #ff4d4f;
+  box-shadow: 0 0 8px rgba(255, 77, 79, 0.6);
+
+  &::before {
+    background-color: rgba(255, 77, 79, 0.3);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.5);
+  }
+}

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { useRequest } from '@umijs/max';
+import { getSandboxInfo, removeSandbox, launchSandboxByUserCode, type SandboxInfo } from '@/service/sandbox';
+
+type SandboxStatus = 'running' | 'transitioning' | 'stopped';
+
+const POLL_INTERVAL = 10000; // 10秒轮询一次
+
+function calculateStatus(sandboxes: SandboxInfo[]): SandboxStatus {
+  if (!sandboxes || sandboxes.length === 0) {
+    return 'stopped';
+  }
+
+  const hasRunning = sandboxes.some((s) => s.status === 'RUNNING');
+  const hasTransitioning = sandboxes.some((s) => ['STARTING', 'RELEASING'].includes(s.status || ''));
+
+  if (hasTransitioning) {
+    return 'transitioning';
+  }
+
+  if (hasRunning) {
+    return 'running';
+  }
+
+  return 'stopped';
+}
+
+export default function useSandboxStatus(userCode: string) {
+  const [status, setStatus] = useState<SandboxStatus>('stopped');
+
+  const {
+    data,
+    loading,
+    run: refetch,
+  } = useRequest(() => getSandboxInfo({ userCode, sandboxType: 'openclaw' }), {
+    pollingInterval: POLL_INTERVAL,
+    ready: !!userCode,
+    onSuccess: (sandboxes: SandboxInfo[]) => {
+      const calculatedStatus = calculateStatus(sandboxes);
+      setStatus(calculatedStatus);
+    },
+    onError: () => {
+      setStatus('stopped');
+    },
+  });
+
+  const restartSandbox = async () => {
+    // 1. 释放当前沙箱
+    await removeSandbox({ userCode, resourceId: null });
+
+    // 等待 2 秒确保释放完成
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 2000);
+    });
+
+    // 2. 重新启动沙箱
+    await launchSandboxByUserCode({ userCode, serviceKey: 'openclaw' });
+
+    // 3. 立即刷新状态
+    await refetch();
+  };
+
+  return {
+    status,
+    isLoading: loading,
+    sandboxes: data || [],
+    refetch,
+    restartSandbox,
+  };
+}

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
@@ -4,7 +4,7 @@ import { getSandboxInfo, removeSandbox, launchSandboxByUserCode, type SandboxInf
 
 type SandboxStatus = 'running' | 'transitioning' | 'stopped';
 
-const POLL_INTERVAL = 10000; // 10秒轮询一次
+const POLL_INTERVAL = 5000; // 5秒轮询一次
 
 function calculateStatus(sandboxes: SandboxInfo[]): SandboxStatus {
   if (!sandboxes || sandboxes.length === 0) {

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useRequest } from '@umijs/max';
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getSandboxInfo, removeSandbox, launchSandboxByUserCode, type SandboxInfo } from '@/service/sandbox';
 
 type SandboxStatus = 'running' | 'transitioning' | 'stopped';
@@ -28,21 +28,21 @@ function calculateStatus(sandboxes: SandboxInfo[]): SandboxStatus {
 export default function useSandboxStatus(userCode: string) {
   const [status, setStatus] = useState<SandboxStatus>('stopped');
 
-  const {
-    data,
-    loading,
-    run: refetch,
-  } = useRequest(() => getSandboxInfo({ userCode, sandboxType: 'openclaw' }), {
-    pollingInterval: POLL_INTERVAL,
-    ready: !!userCode,
-    onSuccess: (sandboxes: SandboxInfo[]) => {
-      const calculatedStatus = calculateStatus(sandboxes);
-      setStatus(calculatedStatus);
-    },
-    onError: () => {
-      setStatus('stopped');
-    },
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['sandboxStatus', userCode],
+    queryFn: () => getSandboxInfo({ userCode, sandboxType: 'openclaw' }),
+    refetchInterval: POLL_INTERVAL,
+    enabled: !!userCode,
   });
+
+  useEffect(() => {
+    if (data) {
+      const calculatedStatus = calculateStatus(data);
+      setStatus(calculatedStatus);
+    } else {
+      setStatus('stopped');
+    }
+  }, [data]);
 
   const restartSandbox = async () => {
     // 1. 释放当前沙箱
@@ -64,7 +64,7 @@ export default function useSandboxStatus(userCode: string) {
 
   return {
     status,
-    isLoading: loading,
+    isLoading,
     sandboxes: data || [],
     refetch,
     restartSandbox,

--- a/byclaw-fe/src/layout/sider/index.tsx
+++ b/byclaw-fe/src/layout/sider/index.tsx
@@ -18,6 +18,7 @@ import useVisibleMenuKeys from './useVisibleMenuKeys';
 import styles from './index.module.less';
 import Icon from '@/components/AntdIcon/icon';
 import Feedback from '../header/components/Feedback';
+import SandboxStatusIndicator from './components/SandboxStatus';
 import useUserDropdown from '../header/useUserDropdown';
 import SiderSearch from './siderSearch';
 import { getDisplayUserNameInChat } from '@/utils/chat';
@@ -349,6 +350,11 @@ const Sidebar = () => {
           userId={userInfo.userId}
           className={classnames(styles.smallIconWrap)}
           style={{ background: 'transparent', marginTop: 'auto' }}
+        />
+        <SandboxStatusIndicator
+          userCode={userInfo.userCode}
+          className={classnames(styles.smallIconWrap)}
+          style={{ background: 'transparent' }}
         />
         <SelectLang placement="right" style={{ fontSize: 16 }} className={styles.smallIconWrap} />
         <Dropdown

--- a/byclaw-fe/src/locales/en-US.ts
+++ b/byclaw-fe/src/locales/en-US.ts
@@ -1583,9 +1583,9 @@ export default {
   'newChat.alreadyLatestSession': 'Already in the latest session',
 
   'sandbox.waitTips': 'Initializing sandbox environment, please wait...',
-  'sandbox.status.running': 'OpenClaw Running',
-  'sandbox.status.transitioning': 'OpenClaw Starting/Stopping',
-  'sandbox.status.stopped': 'OpenClaw Stopped',
+  'sandbox.status.running': 'Sandbox Running',
+  'sandbox.status.transitioning': 'Sandbox Starting/Stopping',
+  'sandbox.status.stopped': 'Sandbox Stopped',
   'sandbox.action.restart': 'Restart Sandbox',
   'sandbox.restart.success': 'Sandbox restarted successfully',
   'sandbox.restart.failed': 'Failed to restart sandbox, please try again later',

--- a/byclaw-fe/src/locales/en-US.ts
+++ b/byclaw-fe/src/locales/en-US.ts
@@ -1583,6 +1583,12 @@ export default {
   'newChat.alreadyLatestSession': 'Already in the latest session',
 
   'sandbox.waitTips': 'Initializing sandbox environment, please wait...',
+  'sandbox.status.running': 'OpenClaw Running',
+  'sandbox.status.transitioning': 'OpenClaw Starting/Stopping',
+  'sandbox.status.stopped': 'OpenClaw Stopped',
+  'sandbox.action.restart': 'Restart Sandbox',
+  'sandbox.restart.success': 'Sandbox restarted successfully',
+  'sandbox.restart.failed': 'Failed to restart sandbox, please try again later',
   'ThinkRewriteQuestion.originalQuestion': 'Original Question',
   'thinkStatus.errorDetail': 'Error Detail',
   compaction: 'Context Compression',

--- a/byclaw-fe/src/locales/zh-CN.ts
+++ b/byclaw-fe/src/locales/zh-CN.ts
@@ -1574,6 +1574,12 @@ export default {
   'newChat.alreadyLatestSession': '已经是最新会话',
 
   'sandbox.waitTips': '正在初始化安全沙箱环境，请稍候...',
+  'sandbox.status.running': 'OpenClaw 运行中',
+  'sandbox.status.transitioning': 'OpenClaw 启动/停止中',
+  'sandbox.status.stopped': 'OpenClaw 已停止',
+  'sandbox.action.restart': '重启沙箱',
+  'sandbox.restart.success': '沙箱重启成功',
+  'sandbox.restart.failed': '沙箱重启失败，请稍后重试',
   'ThinkRewriteQuestion.originalQuestion': '原查询',
   'thinkStatus.errorDetail': '错误详情',
   compaction: '上下文压缩',

--- a/byclaw-fe/src/locales/zh-CN.ts
+++ b/byclaw-fe/src/locales/zh-CN.ts
@@ -1574,9 +1574,9 @@ export default {
   'newChat.alreadyLatestSession': '已经是最新会话',
 
   'sandbox.waitTips': '正在初始化安全沙箱环境，请稍候...',
-  'sandbox.status.running': 'OpenClaw 运行中',
-  'sandbox.status.transitioning': 'OpenClaw 启动/停止中',
-  'sandbox.status.stopped': 'OpenClaw 已停止',
+  'sandbox.status.running': '沙箱运行中',
+  'sandbox.status.transitioning': '沙箱启动/停止中',
+  'sandbox.status.stopped': '沙箱已停止',
   'sandbox.action.restart': '重启沙箱',
   'sandbox.restart.success': '沙箱重启成功',
   'sandbox.restart.failed': '沙箱重启失败，请稍后重试',

--- a/byclaw-fe/src/service/sandbox.ts
+++ b/byclaw-fe/src/service/sandbox.ts
@@ -1,4 +1,4 @@
-import { post } from './common/request';
+import { POST } from './common/request';
 
 export interface SandboxInfo {
   userCode: string;
@@ -21,14 +21,14 @@ export interface LaunchSandboxResult {
  * 查询沙箱信息
  */
 export async function getSandboxInfo(params: { userCode?: string; sandboxType?: string }): Promise<SandboxInfo[]> {
-  return post('/sandbox/getSandboxInfo', params);
+  return POST('/sandbox/getSandboxInfo', params);
 }
 
 /**
  * 释放沙箱
  */
 export async function removeSandbox(params: { userCode: string; resourceId?: number | null }): Promise<void> {
-  return post('/sandbox/removeSandbox', params);
+  return POST('/sandbox/removeSandbox', params);
 }
 
 /**
@@ -38,19 +38,19 @@ export async function launchSandboxByUserCode(params: {
   userCode: string;
   serviceKey?: string;
 }): Promise<LaunchSandboxResult> {
-  return post('/sandbox/launchByUserCode', params);
+  return POST('/sandbox/launchByUserCode', params);
 }
 
 /**
  * 沙箱心跳
  */
 export async function sandboxHeartbeat(params: { resourceId?: number }): Promise<void> {
-  return post('/sandbox/heartbeat', params);
+  return POST('/sandbox/heartbeat', params);
 }
 
 /**
  * 沙箱续约
  */
 export async function renewSandbox(params: { userCode?: string; resourceId?: number }): Promise<SandboxInfo> {
-  return post('/sandbox/renewSandbox', params);
+  return POST('/sandbox/renewSandbox', params);
 }

--- a/byclaw-fe/src/service/sandbox.ts
+++ b/byclaw-fe/src/service/sandbox.ts
@@ -1,0 +1,56 @@
+import { post } from './common/request';
+
+export interface SandboxInfo {
+  userCode: string;
+  sandboxType: string;
+  sandboxId: string;
+  endpoints?: string[];
+  instanceEndpoints?: Record<string, string>;
+  token?: string;
+  status?: string;
+}
+
+export interface LaunchSandboxResult {
+  endpoint: string;
+  sandboxId: string;
+  endpoints?: string[];
+  instanceEndpoints?: Record<string, string>;
+}
+
+/**
+ * 查询沙箱信息
+ */
+export async function getSandboxInfo(params: { userCode?: string; sandboxType?: string }): Promise<SandboxInfo[]> {
+  return post('/sandbox/getSandboxInfo', params);
+}
+
+/**
+ * 释放沙箱
+ */
+export async function removeSandbox(params: { userCode: string; resourceId?: number | null }): Promise<void> {
+  return post('/sandbox/removeSandbox', params);
+}
+
+/**
+ * 按用户工号启动沙箱
+ */
+export async function launchSandboxByUserCode(params: {
+  userCode: string;
+  serviceKey?: string;
+}): Promise<LaunchSandboxResult> {
+  return post('/sandbox/launchByUserCode', params);
+}
+
+/**
+ * 沙箱心跳
+ */
+export async function sandboxHeartbeat(params: { resourceId?: number }): Promise<void> {
+  return post('/sandbox/heartbeat', params);
+}
+
+/**
+ * 沙箱续约
+ */
+export async function renewSandbox(params: { userCode?: string; resourceId?: number }): Promise<SandboxInfo> {
+  return post('/sandbox/renewSandbox', params);
+}

--- a/byclaw-fe/src/service/sandbox.ts
+++ b/byclaw-fe/src/service/sandbox.ts
@@ -21,14 +21,14 @@ export interface LaunchSandboxResult {
  * 查询沙箱信息
  */
 export async function getSandboxInfo(params: { userCode?: string; sandboxType?: string }): Promise<SandboxInfo[]> {
-  return POST('/sandbox/getSandboxInfo', params);
+  return POST('/byaiService/sandbox/getSandboxInfo', params);
 }
 
 /**
  * 释放沙箱
  */
 export async function removeSandbox(params: { userCode: string; resourceId?: number | null }): Promise<void> {
-  return POST('/sandbox/removeSandbox', params);
+  return POST('/byaiService/sandbox/removeSandbox', params);
 }
 
 /**
@@ -38,19 +38,19 @@ export async function launchSandboxByUserCode(params: {
   userCode: string;
   serviceKey?: string;
 }): Promise<LaunchSandboxResult> {
-  return POST('/sandbox/launchByUserCode', params);
+  return POST('/byaiService/sandbox/launchByUserCode', params);
 }
 
 /**
  * 沙箱心跳
  */
 export async function sandboxHeartbeat(params: { resourceId?: number }): Promise<void> {
-  return POST('/sandbox/heartbeat', params);
+  return POST('/byaiService/sandbox/heartbeat', params);
 }
 
 /**
  * 沙箱续约
  */
 export async function renewSandbox(params: { userCode?: string; resourceId?: number }): Promise<SandboxInfo> {
-  return POST('/sandbox/renewSandbox', params);
+  return POST('/byaiService/sandbox/renewSandbox', params);
 }


### PR DESCRIPTION
## 📋 Summary

实现 GitHub issue #175 - 在用户配置区域添加 OpenClaw 沙箱运行状态指示器。

## 🎯 Changes

### Frontend
- ✅ 新增 `SandboxStatusIndicator` 组件，带有状态指示点（绿色/黄色/红色）
- ✅ 新增 `useSandboxStatus` Hook，每 10 秒轮询沙箱状态
- ✅ 新增沙箱 API 服务层（`getSandboxInfo`、`removeSandbox`、`launchSandboxByUserCode`）
- ✅ 将指示器集成到 sider 布局，位于反馈图标和语言选择器之间
- ✅ 添加中英文国际化文案

### Backend
- ✅ 增强 `SandboxController.getSandboxInfo` 接口，返回 `status` 字段
- ✅ 查询 `SsSandboxRecord` 表获取完整的沙箱状态信息

## ✨ Features

| 状态 | 颜色 | 说明 |
|------|------|------|
| 🟢 运行中 | 绿色发光 | 所有沙箱状态为 RUNNING |
| 🟡 启动/停止中 | 黄色发光 | 存在 STARTING 或 RELEASING 状态 |
| 🔴 已停止 | 红色发光 | 所有沙箱已释放（RELEASED） |

- ✅ Hover 显示状态文案
- ✅ 点击弹出操作菜单，提供"重启沙箱"功能
- ✅ 自动每 10 秒刷新状态
- ✅ 圆形发光点 + 呼吸动画效果

## 📁 Files Changed

**Frontend:**
- `byclaw-fe/src/layout/sider/components/SandboxStatus/` (新增)
  - `index.tsx` - 主组件
  - `useSandboxStatus.ts` - 状态管理 Hook
  - `styles.module.less` - 样式（发光效果 + 动画）
- `byclaw-fe/src/service/sandbox.ts` (新增)
- `byclaw-fe/src/layout/sider/index.tsx` (修改)
- `byclaw-fe/src/locales/zh-CN.ts` (修改)
- `byclaw-fe/src/locales/en-US.ts` (修改)

**Backend:**
- `byclaw-be/.../SandboxController.java` (修改)

## 🧪 Test Plan

- [ ] 启动前后端服务
- [ ] 登录后查看右下角用户配置区域
- [ ] 验证沙箱状态指示器显示正确颜色
- [ ] Hover 查看状态文案
- [ ] 点击测试重启功能
- [ ] 验证状态自动刷新（10 秒轮询）

## 🔗 Related Issues

Closes #175

## 📸 Screenshots

_开发完成后补充界面截图_