### PR TITLE
fix(fe,be): sandbox status respects preferredServiceKey mapping

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/gateway/sandbox/controller/SandboxController.java
@@ -297,9 +297,11 @@ public class SandboxController {
             SandboxLaunchData data = sandboxUserContextRunner.callAsUser(userCode,
                 () -> sandboxService.launchSandboxWithServiceKey(userCode, finalServiceKey));
 
-            // 持久化用户首选 serviceKey（非默认类型时）
+            // 持久化用户首选 serviceKey（非默认类型时）；显式回到默认类型时清除旧映射
             if (finalServiceKey != null && !SandboxLaunchRouting.DEFAULT_SANDBOX_TYPE.equals(finalServiceKey)) {
                 sandboxService.savePreferredServiceKey(userCode, finalServiceKey);
+            } else if (SandboxLaunchRouting.DEFAULT_SANDBOX_TYPE.equals(finalServiceKey)) {
+                sandboxService.removePreferredServiceKey(userCode);
             }
 
             if (data == null) {

--- a/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
+++ b/byclaw-fe/src/layout/sider/components/SandboxStatus/useSandboxStatus.ts
@@ -30,7 +30,7 @@ export default function useSandboxStatus(userCode: string) {
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['sandboxStatus', userCode],
-    queryFn: () => getSandboxInfo({ userCode, sandboxType: 'openclaw' }),
+    queryFn: () => getSandboxInfo({ userCode }),
     refetchInterval: POLL_INTERVAL,
     enabled: !!userCode,
   });


### PR DESCRIPTION
Closes #180

## 问题

adminvip 通过「指定用户启动沙箱」为 userA 启动非默认类型沙箱（如 `byclaw-code-agent`）后，后端会写入 Redis `preferredServiceKey = "byclaw-code-agent"`。此时：

1. 登录页沙箱状态仍显示「已停止」——前端查询时过滤了 `sandboxType: 'openclaw'`，实际运行的 `byclaw-code-agent` 沙箱被后端过滤掉
2. 用户点击「重启」后，以 `openclaw` 启动了新沙箱，但 Redis 里的 `preferredServiceKey` 未清除，后续 `resolveRouting` 仍路由到不存在的 `byclaw-code-agent`

## 改动

**前端**（`useSandboxStatus.ts`）：查询状态时不传 `sandboxType` 过滤参数，后端返回该用户所有运行中沙箱，自动识别 `preferredServiceKey` 映射后的类型。

**后端**（`SandboxController.java`）：`launchByUserCode` 传入默认类型（`openclaw`）时，调用 `removePreferredServiceKey` 清除旧映射，避免重启后遗留脏缓存。

## 验收

- adminvip 为 userA 启动 `byclaw-code-agent` 沙箱 → userA 页面状态显示「运行中」
- 默认 `openclaw` 沙箱正常运行时状态不变
- 用户点「重启」→ 恢复 `openclaw` 沙箱 → `preferredServiceKey` 自动清除 → 后续路由正常