### PR TITLE
feat(openclaw): 支持企业生态知识采集入库

### DIFF
--- a/middleware/openclaw/skills/agent-reach/SKILL.md
+++ b/middleware/openclaw/skills/agent-reach/SKILL.md
@@ -46,6 +46,9 @@ description: Use when the user asks to research, search, read, or look up anythi
    企业微信/WeCom 的对应请求，加载并遵循 `wecomcli` skill，再由其选择具体业务能力；钉钉/DingTalk 的对应请求，
    加载并遵循 `dws` skill。`byclaw-capability-doctor` 中已有的 provider 状态仅用于被动诊断，
    不能替代业务 Skill 的意图路由、授权与调用流程。
+11. 企业来源的采集、归档、批量搜索或入库请求交给采集编排器 `knowledge-collection`；其按来源加载 WeCom 或 Feishu
+    采集桥接，再委派 `wecomcli` 或 `fws`。路由器只完成该交接与被动诊断，不得作为公共互联网任务交给 `bycli`，
+    不得自行执行企业 CLI、管理采集产物、凭据或后处理。
 
 ## Agent Reach 官方主体（v1.5.0）
 

--- a/middleware/openclaw/skills/bycli/SKILL.md
+++ b/middleware/openclaw/skills/bycli/SKILL.md
@@ -30,6 +30,10 @@ byCLI 将网站、Electron 应用和外部 CLI 统一为 `bycli <site> <command>
 
 任何命令返回认证、人工验证、桥接不可用或安全相关 STOP 条件时，停止当前 workflow，不为“补充信息”自行扩大操作范围。
 
+## 规则优先级
+
+规则冲突时，按以下顺序处理：用户明确的当前操作范围和安全边界；本 Skill 的 STOP / 认证 / 浏览器生命周期规则；最后才是所选 workflow reference。遇到 STOP 条件时停止当前工作流，不为了补充信息扩大操作范围。
+
 ## 硬规则
 
 ### 1. 路由与命令边界
@@ -51,7 +55,7 @@ byCLI 将网站、Electron 应用和外部 CLI 统一为 `bycli <site> <command>
 - 不在 browser 命令中硬编码 CSS selector；按 [references/browser.md](./references/browser.md) 使用实时 ref 和 target contract。
 - 不确定 TAB 目标时停止并请用户确认；不得猜测后导航、自动换 session 或新建 TAB。
 
-### 3. 认证、人工验证和 STOP
+## 认证、人工验证与 STOP
 
 以下情况不修改 adapter、不自动降级、不重试：
 
@@ -99,12 +103,12 @@ Weixin 任务必须优先读取 [references/weixin/SKILL.md](./references/weixin
 | 已有 Markdown 内容请求入库 | 直接交给 knowledge-ingest | [knowledge-ingest.md](./references/knowledge-ingest.md) |
 | 已有内容请求知识整理 | 委派 knowledge-organizer，不执行入库 | 对应 knowledge-organizer skill |
 
-### 查询与采集边界
+### 查询 vs 采集边界
 
 | 场景 | 行为 |
 |---|---|
-| 查一个事实、看一个页面、打开网页、登录、读一篇内容、一次站点操作 | 完成请求，不主动问入库或知识整理 |
-| “采集 / 抓取 / 爬取 / 批量获取 / 搜索结果 / 多篇正文 / 存知识库”，或结构化多条结果 / 批量正文 | 视为采集任务：成功后先落盘，再问处理动作 |
+| 查一个事实、看一个页面、打开网页、登录、读一篇内容、一次站点操作 | 完成请求即可，不主动问入库或知识整理 |
+| “采集 / 抓取 / 爬取 / 批量获取 / 搜索结果 / 多篇正文 / 存知识库”，或结构化多条结果 / 批量正文 | 视为采集任务，成功后先落盘，再问处理动作 |
 | “保存文件 / 下载” | 只做本地文件保存，不触发知识处理询问 |
 | “记住这个” | 按对话记忆或用户指定机制处理，不触发 knowledge-ingest / knowledge-organizer |
 
@@ -154,6 +158,7 @@ bycli daemon status
 3. 仍未连接时 STOP：提示用户检查 Chrome 和 byCLI Extension，停止一切浏览器动作，不降级到通用工具。
 
 冷启动不包含 `bycli browser open` / `state` / `tab list`，浏览器已运行时不得重复执行启动脚本。
+浏览器恢复不得执行 `openclaw browser --browser-profile openclaw stop`；共享 daemon 和 Chromium 也不得停止。
 
 ### 2. TAB 分流
 
@@ -170,11 +175,13 @@ TAB 约束：同名 session 只有在相同 surface、browser context 和存活 
 
 ### 3. 关闭和异常
 
-清理遵循“采集或浏览任务结束时只关闭当前任务使用的浏览器 Tab”原则。当前页不是登录 / 验证 / CAPTCHA / 反爬页面且没有后续复用需求时：
+清理遵循“只清理当前任务创建或独占拥有的资源”原则。采集或浏览任务结束时只关闭当前任务使用的浏览器 Tab。当前页不是登录 / 验证 / CAPTCHA / 反爬页面且没有后续复用需求时：
 
 - 当前任务创建或独占拥有的 TAB：执行 `bycli browser <session> close`。
 - 永远不要主动停止 daemon 或 Chromium；Chrome 实例由运行环境负责管理并保持存活。
 - 无法确认 TAB 所有权时，不关闭该 TAB；不得为了清理方便关闭用户或共享资源。
+- 不得执行 `bycli daemon stop` 或 `openclaw browser --browser-profile openclaw stop`。
+- 不得执行 `pkill`、kill-all 或停止共享进程。
 
 异常或卡死时，不执行全局进程终止，不停止 daemon 或 Chromium，也不关闭无法确认归属的 TAB。先报告原始错误；仅在能精确确认 TAB 由当前任务创建或独占使用时，才释放该 TAB，否则停止并请用户或运行环境管理员手动处理。
 
@@ -245,6 +252,16 @@ TAB 约束：同名 session 只有在相同 surface、browser context 和存活 
 保留策略：落盘后保留；入库成功且用户未要求保留时可由 knowledge-ingest 清理已归档时间戳目录；知识整理成功、任一处理失败、用户跳过或明确要求保留时均保留；session 结束不主动清理。
 
 用户明确要求清理时，先列出目标时间戳目录（降序），默认保留最近 10 次，`audit_required=true` 不可删，二次确认后只删目录内容、不删目录本身。
+
+### 采集编排与收尾问题
+
+bycli 是网页和采集入口；采集后处理衔接（强制）与采集产物落盘约定（强制）由 bycli 内部遵守。产物使用 `bycli-output.json` 和 `bycli_filter`，入库交给 `knowledge-ingest.md`，知识整理交给 `knowledge-organizer`；旧版 `bycli-markdown-ingest.mjs` 仅作兼容参考。
+
+问题 ①「复用」：是否把刚才的获取过程保存成一个专用 adapter？
+
+问题 ②「处理」：是否选择入库 / 知识整理 / 跳过？
+
+问①与问②相互独立；①②**都要问**时，按顺序询问，但都不自动执行。采集产物保留策略遵循上方处理动作与保留规则。
 
 ## 结果展示
 

--- a/middleware/openclaw/skills/knowledge-collection/SKILL.md
+++ b/middleware/openclaw/skills/knowledge-collection/SKILL.md
@@ -19,8 +19,8 @@ description: Use when the user asks to collect, crawl, batch-search, archive, in
 - 公共互联网：加载并遵循 `agent-reach` skill。
 - `agent-reach` 选择 `bycli`，或用户显式要求 byCLI、浏览器或 Adapter 执行：加载并遵循 `bycli` skill。
 - 钉钉/DingTalk：加载并遵循 `dws` skill，并遵循 [DingTalk DWS 采集桥接](references/sources/dingtalk-dws.md)。
-- 飞书/Lark：加载并遵循 `fws` skill。
-- 企业微信/WeCom：加载并遵循 `wecomcli` skill。
+- 飞书/Lark：加载并遵循 `fws` skill，并遵循 [Feishu 采集桥接](references/sources/feishu-fws.md)。
+- 企业微信/WeCom：加载并遵循 `wecomcli` skill，并遵循 [WeCom 采集桥接](references/sources/wecom-wecomcli.md)。
 
 Agent Reach 直接后端与 `bycli` 后端返回的结果必须统一进入同一套 collection contract，不得按执行后端分叉产物协议。
 

--- a/middleware/openclaw/skills/knowledge-collection/references/knowledge-ingest.md
+++ b/middleware/openclaw/skills/knowledge-collection/references/knowledge-ingest.md
@@ -9,7 +9,9 @@
 - 先用 `list-kb` 发现可选知识库。目标有歧义时不得静默选择：要求用户明确提供目标
   `--knowledge-base-resource-id`，或展示候选并让用户确认目标。
 - `ingest` 与 `upload-doc` 执行前，都必须展示解析后的目标目录并获得用户明确确认；脚本采用的
-  默认 `/` 也必须展示，不得把缺省目录视为用户已经确认。
+  默认 `/` 也必须展示，不得把缺省目录视为用户已经确认。真实写入时必须把已经确认的目标通过
+  `--confirmed-knowledge-base-resource-id` 与 `--confirmed-directory-path` 传给脚本，且确认值必须与解析后的
+  知识库资源 ID 和目录完全一致；`--dry-run` 只展示所需确认值，不执行写入。
 - 仅入库用户选中的范围，包括已确认的条目、Markdown 或文件；不得扩大到同一目录或采集批次的其他产物。
 - 入库与知识整理互斥；同一批结果执行 `ingest` 或 `upload-doc` 后，不得再交给知识整理。
 
@@ -25,10 +27,17 @@
   新产物仍写规范格式。
 - `ingest`：将用户选中的 Markdown 文件、Markdown 目录或规范化采集结果交给
   `by-knowledge-manager` 执行 upload/build；知识库目标使用 `--knowledge-base-resource-id`，也兼容
-  `--knowledge-base-id`，目录使用 `--directory-path`；这些值必须先按上方边界获得用户确认。
+  `--knowledge-base-id`（脚本会通过 `list-kb` 将旧数据集 ID 解析为实际资源 ID），目录使用
+  `--directory-path`；这些值必须先按上方边界获得用户确认，并用对应的
+  `--confirmed-knowledge-base-resource-id` 与 `--confirmed-directory-path` 绑定本次写入。
+- 使用 `--check-conflicts` 返回 `confirm-overwrite` 时，脚本会保留本次 Markdown，并在 `continuation` 中
+  返回恢复所需路径。用户明确确认全部 `overwritePaths` 后，以保留的 `--markdown-file` 重试，并逐个传入
+  `--confirmed-overwrite-path`；脚本会重新检查冲突集合，完全一致时才调用覆盖接口。恢复调用不得重新传入
+  已经成功上传的图片、音频或视频。
 - `upload-doc`：仅在用户选中受支持的文档时直传。脚本支持
   `pdf/docx/pptx/xlsx/csv/txt/md`；知识库目标必须使用 `--knowledge-base-resource-id`，目录使用
-  `--directory-path`，并且必须先按上方边界获得用户确认。
+  `--directory-path`，并且必须先按上方边界获得用户确认，再传入对应的
+  `--confirmed-knowledge-base-resource-id` 与 `--confirmed-directory-path`。
 
 具体参数以 `node scripts/knowledge-collection-ingest.mjs --help` 为准。命令和示例中只使用资源 ID、
 目录与本地文件路径等非敏感占位值。

--- a/middleware/openclaw/skills/knowledge-collection/references/sources/feishu-fws.md
+++ b/middleware/openclaw/skills/knowledge-collection/references/sources/feishu-fws.md
@@ -1,0 +1,82 @@
+# Feishu FWS 采集桥接
+
+飞书采集意图由 `knowledge-collection` 统一编排。命中本桥接后，先声明“委派采集模式”，再加载并遵循
+`fws` skill 及匹配的产品参考。`knowledge-collection` 负责采集目录、`raw/`、`markdown/`、
+`sanitized/items/`、`sanitized/metadata.json`、`collection-result.json`、预览和唯一后处理选择；
+`fws` / `lark-cli` 只负责飞书产品路由、命令、身份、授权、权限、真实 token、分页和只读取数。
+
+## 来源路由
+
+| 输入 | 委派能力 |
+|---|---|
+| 飞书文档、云盘文件或 Wiki 内容 | `docs` / `drive` / `wiki` |
+| 飞书妙记、会议转写、AI 笔记或录音 | `vc` / `minutes` |
+| 电子表格或 Base 记录 | `sheets` / `base` |
+| 聊天、消息历史或资源文件 | `im` |
+| 日历、任务、邮件、审批、考勤、通讯录或幻灯片 | 匹配的 `fws` 产品能力 |
+
+仅允许读取、搜索、导出、下载和采集。创建、编辑、发送、审批、移动、权限变更或删除飞书资源属于直接 `fws` 写操作，
+不能进入本采集桥接。
+
+飞书采集不得通过浏览器、curl、直接 HTTP/API 或通用网页抓取降级。产品能力不支持时，仅可按 `fws` 的 OpenAPI
+参考处理已检查 schema 的只读请求；其他替代工具必须先经用户确认，且不属于本桥接。
+
+## 执行与认证
+
+1. 加载并遵循 `fws` skill，再按 URL 或产品意图加载 `references/products/<product>.md`。
+2. 优先使用 `lark-cli <service> +<shortcut>`；业务命令使用 `--format json`，用户可见个人资源按 `fws` 规则选择
+   `--as user`。
+3. 成功依据进程退出码或顶层 `ok == true`；不得把嵌套 OpenAPI `code` 当作唯一成功条件。
+4. 缺少 OpenClaw 飞书渠道时，遵循 `fws` 的渠道配置流程；用户身份 401/403、失效登录、`missing_scope` 或
+   `permission_violations` 时，遵循 `fws` 的授权 split-flow，只请求实际报告缺失的 scope。`lark-cli 1.0.78` 的
+   `im +messages-search --no-reactions` 仍可能预检 reactions scope，必须如实报告，不得把无关 scope 伪称为已授权。
+   若 QR 生成失败而返回验证 URL，必须展示该**可点击**链接并同时说明 QR helper 失败；不得阻塞、伪造二维码或宣称认证成功。
+5. 不得在聊天、原始产物或规范化产物写入 App Secret、access/refresh token、device code、Cookie 或会话。
+
+### 妙记转写
+
+妙记 URL 或 minute token 采集需加载 `vc` 产品参考，并使用真实 minute token：
+
+```bash
+lark-cli minutes +detail --minute-tokens <minute-token> --transcript --as user --format json
+```
+
+若命令产生转写文件，必须读取实际生成的文件名和内容，保留说话人、时间戳、顺序和正文；不得猜测文件名或编造
+不存在的摘要、章节、录音或转写。分页或文件读取中断时保留成功结果，在 `sanitized/metadata.json` 写入
+`partial: true` 与非敏感失败位置。授权中断发生在相对时间窗口时，恢复后必须重新计算结束时间，或补采并按
+`message_id` 去重；不得把中断前的窗口误报为完整结果。
+
+### 消息与通讯录完整性
+
+- 消息历史先搜索，再以每批最多 50 条的 `mget` 获取正文；比较返回 ID 与请求 ID，缺失、重复或失败时保留 partial/missing
+  信息，未比较前不得宣称完整。
+- 通讯录使用 `contact +search-user` 及真实查询/筛选条件。“我的联系人”含义不清时先澄清；命令成功返回零条是有效结果，
+  不得捏造联系人。
+
+## 私有产物
+
+采集根目录必须使用 `0700`，写入的 raw、markdown、sanitized 与 JSON 文件必须使用 `0600`。若工作区内的回退目录
+没有被 gitignore，必须改用工作区外的私有目录并明确报告；不得暂存、提交或上传任何采集产物。原始 CLI 输出和转写文件描述
+都须先进行秘密扫描，规范化结果只保留完成采集所需的非敏感字段。
+
+## 规范化产物
+
+采集根目录遵循 [collection contract](../collection-contract.md)，至少写入：
+
+```text
+collection-result.json
+raw/
+  metadata.json
+  <lark-command>.json
+markdown/
+  <normalized-content>.md
+sanitized/
+  metadata.json
+  items/
+    <normalized-content>.md
+```
+
+- `raw/` 保存已秘密扫描的 CLI JSON 和真实导出文件描述；`markdown/` 保存规范化正文；`sanitized/items/` 保存净化正文。
+- `collection-result.json` 顶层只能使用主契约固定字段，`source` 写 `fws`，`backend` 写 `lark-cli`。
+- 每个 `items[].fileName` 与 `items[].markdown` 必须是采集根目录内指向实际 `sanitized/items/*.md` 文件的相对路径。
+- 来源执行器不得询问或执行 `入库 / 知识整理 / 跳过`；仅由 `knowledge-collection` 在采集后执行该选择。

--- a/middleware/openclaw/skills/knowledge-collection/references/sources/wecom-wecomcli.md
+++ b/middleware/openclaw/skills/knowledge-collection/references/sources/wecom-wecomcli.md
@@ -1,0 +1,81 @@
+# WeCom wecom-cli 采集桥接
+
+企微采集意图由 `knowledge-collection` 统一编排。命中本桥接后，先声明“委派采集模式”，再加载并遵循
+`wecomcli` skill 及匹配的子 Skill。`knowledge-collection` 负责采集目录、`raw/`、`markdown/`、
+`sanitized/items/`、`sanitized/metadata.json`、`collection-result.json`、预览和唯一后处理选择；
+`wecomcli` / `wecom-cli` 只负责企微 URL 或产品路由、只读命令、认证、权限、真实 ID、导出轮询和分页。
+
+## 来源路由
+
+| 输入 | 委派能力 |
+|---|---|
+| `doc.weixin.qq.com/doc/*` | `wecomcli-doc` |
+| `doc.weixin.qq.com/sheet/*` | `wecomcli-sheet` |
+| `doc.weixin.qq.com/smartsheet/*` | `wecomcli-smartsheet` |
+| `doc.weixin.qq.com/smartpage/*` | `wecomcli-smartpage` |
+| 会话、消息历史或附件 | `wecomcli-msg` |
+| 通讯录、会议、日程或待办数据 | 匹配的 `wecomcli-*` 子 Skill |
+
+仅允许读取、搜索、导出、下载和采集。发送消息、创建、编辑、取消或删除企微资源属于直接业务操作，不能进入本采集桥接。
+
+企微采集不得通过浏览器、curl、直接 HTTP/API 或通用网页抓取降级。`wecom-cli` 不可用或明确不支持时，报告该
+后端结果并停止；不得编造替代数据或绕过用户权限。
+
+## 执行与认证
+
+1. 加载并遵循 `wecomcli` skill，再按 URL 或产品意图加载匹配的子 Skill。
+2. 所有命令、参数、分页、轮询、附件和危险操作规则以子 Skill 与 `wecom-cli --help` 为准；不得猜测。
+3. `wecom-cli 0.1.9` 可能返回 JSON-RPC 外层响应，业务 JSON 位于 `result.content[].text`。必须先解析外层 JSON-RPC，
+   再解析该文本中的业务 JSON；不能只因外层 `isError=false` 或进程成功而判断成功，只有嵌套业务 `errcode == 0` 才能继续。
+4. 认证、初始化或 MCP 配置错误遵循 `wecomcli` 的当前认证流程；权限拒绝、无效 ID、文档类型不兼容或数据不存在
+   直接报告，不得盲目重试认证。初始化返回的授权 URL 过期后，丢弃旧 URL 并开始新的允许轮次；不得复用旧 URL、
+   轮询已经结束的进程，或在授权真正完成前宣称成功。
+5. 不得在聊天、原始产物或规范化产物写入 token、Cookie、会话、授权缓存或任何凭据。
+
+### 范围、分页与完整性
+
+- 通讯录与会话仅代表机器人可见范围（`bot-visible`），不得称为个人或企业完整存档；通讯录子 Skill 每次最多处理 10 人。
+- 不得编造 `chat_type`；消息历史的 7 天限制不得静默截断。记录用户请求窗口、实际窗口、cursor、已取数量、去重结果和
+  `partial` 状态；中断时保留已成功页而非补造缺失页。
+- 产物元数据记录非敏感的后端 CLI version、有效权限范围和任务 ID。只在成功解析后的实际字段上生成正文。
+
+### Smartpage 导出
+
+智能文档导出固定使用异步两步只读流程：
+
+```bash
+wecom-cli doc smartpage_export_task '{"url":"<smartpage-url>","content_type":1}'
+wecom-cli doc smartpage_get_export_result '{"task_id":"<returned-task-id>"}'
+```
+
+首次命令返回真实 `task_id` 后轮询第二个命令，直到 `task_done=true`。未完成、超时或分页中断时保留成功响应，在
+`sanitized/metadata.json` 写入 `partial: true` 与非敏感 task ID/失败位置；完成后只使用返回的 `content` 生成正文，
+不得补造内容。
+
+## 私有产物
+
+采集根目录必须使用 `0700`，写入的 raw、markdown、sanitized 与 JSON 文件必须使用 `0600`。若工作区内的回退目录
+没有被 gitignore，必须改用工作区外的私有目录并明确报告；不得暂存、提交或上传任何采集产物。保留 JSON-RPC 原始响应前
+先做秘密扫描，规范化数据只保留必要的非敏感业务字段。
+
+## 规范化产物
+
+采集根目录遵循 [collection contract](../collection-contract.md)，至少写入：
+
+```text
+collection-result.json
+raw/
+  metadata.json
+  <wecom-command>.json
+markdown/
+  <normalized-content>.md
+sanitized/
+  metadata.json
+  items/
+    <normalized-content>.md
+```
+
+- `raw/` 保存已秘密扫描的后端 JSON；`markdown/` 保存由真实内容转换的 Markdown；`sanitized/items/` 保存净化正文。
+- `collection-result.json` 顶层只能使用主契约固定字段，`source` 写 `wecom`，`backend` 写 `wecom-cli`。
+- 每个 `items[].fileName` 与 `items[].markdown` 必须是采集根目录内指向实际 `sanitized/items/*.md` 文件的相对路径。
+- 来源执行器不得询问或执行 `入库 / 知识整理 / 跳过`；仅由 `knowledge-collection` 在采集后执行该选择。

--- a/middleware/openclaw/skills/knowledge-collection/scripts/enterprise-collection.mjs
+++ b/middleware/openclaw/skills/knowledge-collection/scripts/enterprise-collection.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import { chmod, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { isAbsolute, resolve } from 'node:path';
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const MAX_WECOM_POLLS = 12;
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const values = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith('--')) {
+      throw new Error(`unexpected argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`missing value for --${key}`);
+    }
+    values[key] = value;
+    index += 1;
+  }
+  return { command, values };
+}
+
+function requireValue(values, key) {
+  const value = values[key]?.trim();
+  if (!value) {
+    throw new Error(`--${key} is required`);
+  }
+  return value;
+}
+
+async function makeDirectory(path) {
+  await mkdir(path, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  await chmodPrivate(path);
+}
+
+async function chmodPrivate(path) {
+  await chmod(path, PRIVATE_DIRECTORY_MODE);
+}
+
+async function writePrivate(path, content) {
+  await writeFile(path, content, { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
+  await chmod(path, PRIVATE_FILE_MODE);
+}
+
+async function writePrivateJson(path, value) {
+  await writePrivate(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(bin, args) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolveRun(stdout);
+      } else {
+        reject(new Error(`command failed with exit ${code}: ${stderr.trim() || 'no error output'}`));
+      }
+    });
+  });
+}
+
+function parseWecomEnvelope(stdout) {
+  let outer;
+  try {
+    outer = JSON.parse(stdout);
+  } catch {
+    throw new Error('wecom-cli returned invalid JSON');
+  }
+  const text = outer?.result?.content?.find((item) => typeof item?.text === 'string')?.text;
+  if (!text) {
+    throw new Error('wecom-cli JSON-RPC response has no result.content[].text');
+  }
+  let business;
+  try {
+    business = JSON.parse(text);
+  } catch {
+    throw new Error('wecom-cli result.content[].text is not valid business JSON');
+  }
+  if (business.errcode !== 0) {
+    throw new Error(`wecom-cli business errcode ${business.errcode}`);
+  }
+  return { outer, business };
+}
+
+function markdown(content, url, title, source) {
+  return `---\ntitle: ${title}\nsource: ${source}\nsource_url: ${url}\ncollection_filters: {}\n---\n\n${content.trim()}\n`;
+}
+
+async function collectWecomSmartpage(values) {
+  const url = requireValue(values, 'url');
+  const outputDir = requireValue(values, 'output-dir');
+  if (!isAbsolute(outputDir)) {
+    throw new Error('--output-dir must be an absolute path');
+  }
+  const root = resolve(outputDir);
+  const rawDir = resolve(root, 'raw');
+  const markdownDir = resolve(root, 'markdown');
+  const sanitizedDir = resolve(root, 'sanitized');
+  const itemDir = resolve(sanitizedDir, 'items');
+  await makeDirectory(root);
+  await Promise.all([makeDirectory(rawDir), makeDirectory(markdownDir), makeDirectory(sanitizedDir), makeDirectory(itemDir)]);
+
+  const bin = process.env.WECOM_CLI_BIN || 'wecom-cli';
+  const exportResult = parseWecomEnvelope(await run(bin, ['doc', 'smartpage_export_task', JSON.stringify({ url, content_type: 1 })]));
+  await writePrivateJson(resolve(rawDir, 'export-task.json'), exportResult.outer);
+  const taskId = exportResult.business.task_id;
+  if (typeof taskId !== 'string' || !taskId) {
+    throw new Error('wecom-cli export response has no task_id');
+  }
+
+  let content;
+  for (let poll = 1; poll <= MAX_WECOM_POLLS; poll += 1) {
+    const pollResult = parseWecomEnvelope(await run(bin, ['doc', 'smartpage_get_export_result', JSON.stringify({ task_id: taskId })]));
+    await writePrivateJson(resolve(rawDir, `poll-${poll}.json`), pollResult.outer);
+    if (pollResult.business.task_done === true) {
+      content = pollResult.business.content;
+      break;
+    }
+  }
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('wecom-cli export did not finish with non-empty content');
+  }
+
+  const normalized = markdown(content, url, 'Exported WeCom Smartpage', 'wecom');
+  await Promise.all([
+    writePrivate(resolve(markdownDir, 'document.md'), normalized),
+    writePrivate(resolve(itemDir, 'document.md'), normalized),
+    writePrivateJson(resolve(rawDir, 'metadata.json'), { backend: 'wecom-cli', taskId }),
+    writePrivateJson(resolve(sanitizedDir, 'metadata.json'), {
+      backend: 'wecom-cli',
+      backendCliVersion: process.env.WECOM_CLI_VERSION || 'unknown',
+      scope: 'bot-visible',
+      taskId,
+      partial: false,
+    }),
+  ]);
+  await writePrivateJson(resolve(root, 'collection-result.json'), {
+    schemaVersion: '1.0',
+    title: 'Exported WeCom Smartpage',
+    source: 'wecom',
+    backend: 'wecom-cli',
+    url,
+    filters: {},
+    items: [{
+      title: 'Exported WeCom Smartpage',
+      url,
+      author: '',
+      publishTime: '',
+      markdown: 'sanitized/items/document.md',
+      fileName: 'sanitized/items/document.md',
+    }],
+  });
+}
+
+async function filesBelow(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await filesBelow(path));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+async function collectFeishuMinutes(values) {
+  const minuteToken = requireValue(values, 'minute-token');
+  const url = requireValue(values, 'url');
+  const outputDir = requireValue(values, 'output-dir');
+  if (!isAbsolute(outputDir)) {
+    throw new Error('--output-dir must be an absolute path');
+  }
+  const root = resolve(outputDir);
+  const rawDir = resolve(root, 'raw');
+  const minutesDir = resolve(rawDir, 'minutes');
+  const markdownDir = resolve(root, 'markdown');
+  const sanitizedDir = resolve(root, 'sanitized');
+  const itemDir = resolve(sanitizedDir, 'items');
+  await makeDirectory(root);
+  await Promise.all([
+    makeDirectory(rawDir),
+    makeDirectory(minutesDir),
+    makeDirectory(markdownDir),
+    makeDirectory(sanitizedDir),
+    makeDirectory(itemDir),
+  ]);
+
+  const stdout = await run(process.env.LARK_CLI_BIN || 'lark-cli', [
+    'minutes', '+detail', '--minute-tokens', minuteToken, '--transcript',
+    '--output-dir', minutesDir, '--as', 'user', '--format', 'json',
+  ]);
+  let detail;
+  try {
+    detail = JSON.parse(stdout);
+  } catch {
+    throw new Error('lark-cli returned invalid JSON');
+  }
+  if (detail.ok !== true) {
+    throw new Error('lark-cli did not report success');
+  }
+  await writePrivateJson(resolve(rawDir, 'detail.json'), detail);
+
+  const transcripts = await filesBelow(minutesDir);
+  if (transcripts.length !== 1) {
+    throw new Error(`expected one CLI-created transcript file, found ${transcripts.length}`);
+  }
+  const transcriptPath = transcripts[0];
+  await chmod(transcriptPath, PRIVATE_FILE_MODE);
+  const transcript = await readFile(transcriptPath, 'utf8');
+  if (!transcript.trim()) {
+    throw new Error('CLI-created transcript file is empty');
+  }
+  const title = 'Feishu Minutes Transcript';
+  const normalized = markdown(transcript, url, title, 'fws');
+  await Promise.all([
+    writePrivate(resolve(markdownDir, 'transcript.md'), normalized),
+    writePrivate(resolve(itemDir, 'transcript.md'), normalized),
+    writePrivateJson(resolve(rawDir, 'metadata.json'), { backend: 'lark-cli' }),
+    writePrivateJson(resolve(sanitizedDir, 'metadata.json'), {
+      backend: 'lark-cli',
+      backendCliVersion: process.env.LARK_CLI_VERSION || 'unknown',
+      partial: false,
+      transcriptFile: 'raw/minutes/cli-created-file',
+    }),
+  ]);
+  await writePrivateJson(resolve(root, 'collection-result.json'), {
+    schemaVersion: '1.0',
+    title,
+    source: 'fws',
+    backend: 'lark-cli',
+    url,
+    filters: {},
+    items: [{
+      title,
+      url,
+      author: '',
+      publishTime: '',
+      markdown: 'sanitized/items/transcript.md',
+      fileName: 'sanitized/items/transcript.md',
+    }],
+  });
+}
+
+async function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  if (command === 'wecom-smartpage') {
+    await collectWecomSmartpage(values);
+    return;
+  }
+  if (command === 'feishu-minutes') {
+    await collectFeishuMinutes(values);
+    return;
+  }
+  if (!command) {
+    throw new Error(`unsupported command: ${command || '(missing)'}`);
+  }
+  throw new Error(`unsupported command: ${command}`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/middleware/openclaw/skills/knowledge-collection/scripts/enterprise-collection.test.mjs
+++ b/middleware/openclaw/skills/knowledge-collection/scripts/enterprise-collection.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const scriptPath = resolve(dirname(new URL(import.meta.url).pathname), 'enterprise-collection.mjs');
+
+function run(command, args, env) {
+  return new Promise((resolveRun) => {
+    const child = spawn(command, args, { env: { ...process.env, ...env }, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => resolveRun({ code, stdout, stderr }));
+  });
+}
+
+async function createWecomFixture(root, businessFailure = false) {
+  const fixturePath = join(root, 'wecom-cli');
+  const source = `#!/usr/bin/env node
+const { existsSync, writeFileSync } = require('node:fs');
+const stateFile = process.env.WECOM_FIXTURE_STATE;
+const command = process.argv[3];
+const envelope = (business) => JSON.stringify({ jsonrpc: '2.0', result: { content: [{ type: 'text', text: JSON.stringify(business) }] }, isError: false });
+if (command === 'smartpage_export_task') {
+  console.log(envelope(${businessFailure ? "{ errcode: 93001, errmsg: 'denied' }" : "{ errcode: 0, task_id: 'task-1' }"}));
+  process.exit(0);
+}
+if (command === 'smartpage_get_export_result') {
+  if (!existsSync(stateFile)) {
+    writeFileSync(stateFile, 'polled');
+    console.log(envelope({ errcode: 0, task_done: false }));
+  } else {
+    console.log(envelope({ errcode: 0, task_done: true, content: '# Exported smartpage\\n\\nBody' }));
+  }
+  process.exit(0);
+}
+process.exit(2);
+`;
+  await writeFile(fixturePath, source, { mode: 0o700 });
+  await chmod(fixturePath, 0o700);
+  return fixturePath;
+}
+
+async function createLarkFixture(root) {
+  const fixturePath = join(root, 'lark-cli');
+  const source = `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+const args = process.argv.slice(2);
+const valueFor = (flag) => args[args.indexOf(flag) + 1];
+const required = ['minutes', '+detail', '--minute-tokens', '--transcript', '--as', 'user', '--format', 'json', '--output-dir'];
+if (required.some((token) => !args.includes(token)) || valueFor('--minute-tokens') !== 'minute-1') process.exit(2);
+const outputDir = valueFor('--output-dir');
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(join(outputDir, 'actual-transcript.md'), 'Speaker A [00:00]\\nHello from the real transcript.\\n');
+console.log(JSON.stringify({ ok: true, data: { minute_token: 'minute-1' } }));
+`;
+  await writeFile(fixturePath, source, { mode: 0o700 });
+  await chmod(fixturePath, 0o700);
+  return fixturePath;
+}
+
+async function assertMode(path, expected) {
+  const mode = (await stat(path)).mode & 0o777;
+  assert.equal(mode, expected, `${path} mode`);
+}
+
+async function assertPrivateTree(root) {
+  await assertMode(root, 0o700);
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      await assertPrivateTree(path);
+    } else {
+      await assertMode(path, 0o600);
+    }
+  }
+}
+
+async function testWecomExportWritesCanonicalPrivateArtifacts() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'enterprise-collection-test-'));
+  const outputDir = join(tempRoot, 'output');
+  try {
+    const fixture = await createWecomFixture(tempRoot);
+    const result = await run(process.execPath, [scriptPath, 'wecom-smartpage', '--url', 'https://doc.weixin.qq.com/smartpage/x', '--output-dir', outputDir], {
+      WECOM_CLI_BIN: fixture,
+      WECOM_FIXTURE_STATE: join(tempRoot, 'wecom-state'),
+    });
+    assert.equal(result.code, 0, result.stderr);
+    for (const relativePath of [
+      'raw/export-task.json',
+      'raw/poll-1.json',
+      'raw/poll-2.json',
+      'markdown/document.md',
+      'sanitized/items/document.md',
+      'sanitized/metadata.json',
+      'collection-result.json',
+    ]) {
+      await stat(join(outputDir, relativePath));
+    }
+    const metadata = JSON.parse(await readFile(join(outputDir, 'sanitized/metadata.json'), 'utf8'));
+    assert.equal(metadata.scope, 'bot-visible');
+    assert.ok(metadata.backendCliVersion);
+    const collection = JSON.parse(await readFile(join(outputDir, 'collection-result.json'), 'utf8'));
+    assert.deepEqual(Object.keys(collection).sort(), ['backend', 'filters', 'items', 'schemaVersion', 'source', 'title', 'url']);
+    assert.equal(collection.items.length, 1);
+    assert.equal(collection.items[0].markdown, 'sanitized/items/document.md');
+    assert.equal(collection.items[0].fileName, 'sanitized/items/document.md');
+    await assertPrivateTree(outputDir);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function testWecomRejectsNestedBusinessFailure() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'enterprise-collection-test-'));
+  const outputDir = join(tempRoot, 'output');
+  try {
+    const fixture = await createWecomFixture(tempRoot, true);
+    const result = await run(process.execPath, [scriptPath, 'wecom-smartpage', '--url', 'https://doc.weixin.qq.com/smartpage/x', '--output-dir', outputDir], {
+      WECOM_CLI_BIN: fixture,
+      WECOM_FIXTURE_STATE: join(tempRoot, 'wecom-state'),
+    });
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /errcode 93001/);
+    await assert.rejects(stat(join(outputDir, 'collection-result.json')));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function testFeishuMinutesReadsCliCreatedTranscript() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'enterprise-collection-test-'));
+  const outputDir = join(tempRoot, 'output');
+  try {
+    const fixture = await createLarkFixture(tempRoot);
+    const result = await run(process.execPath, [
+      scriptPath,
+      'feishu-minutes',
+      '--minute-token',
+      'minute-1',
+      '--url',
+      'https://example.feishu.cn/minutes/minute-1',
+      '--output-dir',
+      outputDir,
+    ], { LARK_CLI_BIN: fixture });
+    assert.equal(result.code, 0, result.stderr);
+    for (const relativePath of [
+      'raw/detail.json',
+      'raw/minutes/actual-transcript.md',
+      'markdown/transcript.md',
+      'sanitized/items/transcript.md',
+      'sanitized/metadata.json',
+      'collection-result.json',
+    ]) {
+      await stat(join(outputDir, relativePath));
+    }
+    const normalized = await readFile(join(outputDir, 'sanitized/items/transcript.md'), 'utf8');
+    assert.match(normalized, /Speaker A \[00:00\]/);
+    const collection = JSON.parse(await readFile(join(outputDir, 'collection-result.json'), 'utf8'));
+    assert.equal(collection.source, 'fws');
+    assert.equal(collection.backend, 'lark-cli');
+    assert.equal(collection.items[0].markdown, 'sanitized/items/transcript.md');
+    await assertPrivateTree(outputDir);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+await testWecomExportWritesCanonicalPrivateArtifacts();
+await testWecomRejectsNestedBusinessFailure();
+await testFeishuMinutesReadsCliCreatedTranscript();
+console.log('enterprise collection fixture tests passed');

--- a/middleware/openclaw/skills/knowledge-collection/scripts/knowledge-collection-ingest.mjs
+++ b/middleware/openclaw/skills/knowledge-collection/scripts/knowledge-collection-ingest.mjs
@@ -4,14 +4,22 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
+import http from "node:http";
+import https from "node:https";
 import net from "node:net";
 import { spawn } from "node:child_process";
+import { lookup as dnsLookup } from "node:dns/promises";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_CONTEXT_PATH = "/byaiService";
 const DEFAULT_SIGNATURE_SALT = "{#@*A12^c0+}";
 const DEFAULT_BACKEND_SERVICE_NAME = "ByaiService";
 const SERVICE_DISCOVERY_INSTANCE_PREFIX = "byai_gateway:sd:instances:";
+const DEFAULT_RESOURCE_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RESOURCE_BYTES = 50 * 1024 * 1024;
+const DEFAULT_MAX_BATCH_BYTES = 100 * 1024 * 1024;
+const DEFAULT_MAX_RESOURCES = 20;
+const MAX_RESOURCE_REDIRECTS = 5;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CANONICAL_LOCAL_PATH = Symbol("canonicalLocalPath");
 
@@ -71,6 +79,28 @@ function toNumber(value) {
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toPositiveSafeInteger(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value.trim())) {
+    return undefined;
+  }
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function positiveSafeIntegerIfPresent(value, label) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  const parsed = toPositiveSafeInteger(value);
+  if (parsed === undefined) {
+    throw new Error(`${label} 必须是正安全整数`);
+  }
+  return parsed;
 }
 
 function compactObject(value) {
@@ -159,6 +189,19 @@ function parseMaybeJsonText(text) {
 
 function looksLikeHttpUrl(value) {
   return /^https?:\/\//i.test(String(value || ""));
+}
+
+function positiveIntegerEnv(name, fallback) {
+  return toPositiveSafeInteger(firstNonEmpty(process.env[name])) ?? fallback;
+}
+
+function resourceLimits() {
+  return {
+    timeoutMs: positiveIntegerEnv("KNOWLEDGE_COLLECTION_RESOURCE_TIMEOUT_MS", DEFAULT_RESOURCE_TIMEOUT_MS),
+    maxResourceBytes: positiveIntegerEnv("KNOWLEDGE_COLLECTION_MAX_RESOURCE_BYTES", DEFAULT_MAX_RESOURCE_BYTES),
+    maxBatchBytes: positiveIntegerEnv("KNOWLEDGE_COLLECTION_MAX_BATCH_BYTES", DEFAULT_MAX_BATCH_BYTES),
+    maxResources: positiveIntegerEnv("KNOWLEDGE_COLLECTION_MAX_RESOURCES", DEFAULT_MAX_RESOURCES),
+  };
 }
 
 function normalizeBaseUrl(rawBaseUrl) {
@@ -809,7 +852,7 @@ function normalizeResourceCandidate(raw, args, index) {
 }
 
 function collectResourceCandidatesFromValue(value, args) {
-  if (value === undefined || value === null || hasMarkdownPayload(value)) {
+  if (value === undefined || value === null) {
     return [];
   }
   if (typeof value === "string") {
@@ -829,7 +872,20 @@ function collectResourceCandidatesFromValue(value, args) {
     ...asArray(value.resources),
   ];
   const nested = containers.flatMap((item) => collectResourceCandidatesFromValue(item, args));
-  const direct = normalizeResourceCandidate(value, args, nested.length);
+  const directInput = hasMarkdownPayload(value)
+    ? {
+      fileUrl: value.fileUrl,
+      imageUrl: value.imageUrl,
+      iconUrl: value.iconUrl,
+      downloadUrl: value.downloadUrl,
+      path: value.path,
+      fileName: value.fileName,
+      name: value.name,
+      contentType: value.contentType,
+      mimeType: value.mimeType,
+    }
+    : value;
+  const direct = normalizeResourceCandidate(directInput, args, nested.length);
   return direct ? [direct, ...nested] : nested;
 }
 
@@ -857,26 +913,262 @@ function buildResourceCandidates(args, stdinValue) {
   return [...directCandidates, ...collectResourceCandidatesFromValue(stdinValue, args)];
 }
 
-async function resolveResourceBytes(candidate) {
-  if (looksLikeHttpUrl(candidate.source)) {
-    const response = await fetch(candidate.source);
-    if (!response.ok) {
-      throw new Error(`下载资源失败 HTTP ${response.status}: ${candidate.source}`);
+function ipv4Octets(address) {
+  const parts = String(address).split(".").map((part) => Number.parseInt(part, 10));
+  return parts.length === 4 && parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) ? parts : undefined;
+}
+
+function mappedIpv4Address(address) {
+  const normalized = String(address).toLowerCase();
+  const dotted = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (dotted) {
+    return dotted[1];
+  }
+  const hexadecimal = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hexadecimal) {
+    return "";
+  }
+  const high = Number.parseInt(hexadecimal[1], 16);
+  const low = Number.parseInt(hexadecimal[2], 16);
+  return `${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`;
+}
+
+function isUnsafeIpv4(address) {
+  const octets = ipv4Octets(address);
+  if (!octets) {
+    return true;
+  }
+  const [first, second, third] = octets;
+  return first === 0
+    || first === 10
+    || first === 127
+    || (first === 100 && second >= 64 && second <= 127)
+    || (first === 169 && second === 254)
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 0)
+    || (first === 192 && second === 168)
+    || (first === 198 && (second === 18 || second === 19))
+    || (first === 198 && second === 51 && third === 100)
+    || (first === 203 && second === 0 && third === 113)
+    || first >= 224;
+}
+
+function isUnsafeIpAddress(address) {
+  const normalized = String(address).toLowerCase().replace(/^\[|\]$/g, "").split("%")[0];
+  const mapped = mappedIpv4Address(normalized);
+  if (mapped) {
+    return isUnsafeIpv4(mapped);
+  }
+  const family = net.isIP(normalized);
+  if (family === 4) {
+    return isUnsafeIpv4(normalized);
+  }
+  if (family !== 6) {
+    return true;
+  }
+  return normalized === "::"
+    || normalized === "::1"
+    || /^f[cd]/.test(normalized)
+    || /^fe[89ab]/.test(normalized)
+    || /^ff/.test(normalized)
+    || /^2001:db8(?::|$)/.test(normalized);
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function validatedRemoteTarget(rawUrl, args, timeoutMs) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`资源 URL 无效: ${rawUrl}`);
+  }
+  if (!new Set(["http:", "https:"]).has(url.protocol)) {
+    throw new Error(`资源 URL 只允许 http 或 https: ${url.protocol}`);
+  }
+  if (url.username || url.password) {
+    throw new Error("资源 URL 不得包含用户名或密码");
+  }
+  const allowPrivateResource = args["allow-private-resource"] === true;
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "metadata.google.internal") {
+    if (!allowPrivateResource) {
+      throw new Error(`资源 URL 指向私有或保留地址: ${hostname}`);
     }
-    const bytes = Buffer.from(await response.arrayBuffer());
-    const contentType = firstNonEmpty(response.headers.get("content-type"), candidate.contentType, guessContentType(candidate.fileName));
-    return { bytes, contentType };
+  }
+  let addresses;
+  if (net.isIP(hostname)) {
+    addresses = [{ address: hostname, family: net.isIP(hostname) }];
+  } else {
+    try {
+      addresses = await withTimeout(
+        dnsLookup(hostname, { all: true, verbatim: true }),
+        timeoutMs,
+        `资源下载超时（${timeoutMs}ms）: ${url.href}`,
+      );
+    } catch (error) {
+      throw new Error(`资源主机解析失败: ${hostname}: ${error.message}`);
+    }
+  }
+  if (!addresses.length) {
+    throw new Error(`资源主机没有可用地址: ${hostname}`);
+  }
+  if (!allowPrivateResource && addresses.some((item) => isUnsafeIpAddress(item.address))) {
+    throw new Error(`资源 URL 指向私有或保留地址: ${hostname}`);
+  }
+  return { url, addresses };
+}
+
+function downloadRemoteHop(target, candidate, limits, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const transport = target.url.protocol === "https:" ? https : http;
+    const addresses = target.addresses.map((item) => ({ address: item.address, family: item.family }));
+    const request = transport.request(target.url, {
+      method: "GET",
+      headers: { Accept: "*/*" },
+      lookup(_hostname, options, callback) {
+        if (options?.all) {
+          callback(null, addresses);
+          return;
+        }
+        callback(null, addresses[0].address, addresses[0].family);
+      },
+    });
+    let settled = false;
+    const timer = setTimeout(() => {
+      request.destroy(new Error(`资源下载超时（${limits.timeoutMs}ms）: ${target.url.href}`));
+    }, timeoutMs);
+
+    function finish(error, value) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(value);
+      }
+    }
+
+    request.once("error", (error) => finish(error));
+    request.once("response", async (response) => {
+      try {
+        const status = response.statusCode || 0;
+        if (status >= 300 && status < 400 && response.headers.location) {
+          response.destroy();
+          finish(undefined, { redirect: new URL(response.headers.location, target.url).href });
+          return;
+        }
+        if (status < 200 || status >= 300) {
+          response.destroy();
+          throw new Error(`下载资源失败 HTTP ${status}: ${target.url.href}`);
+        }
+        const contentLength = Number.parseInt(firstNonEmpty(response.headers["content-length"]), 10);
+        if (Number.isFinite(contentLength) && contentLength > limits.maxResourceBytes) {
+          response.destroy();
+          throw new Error(`资源超过单文件大小上限 ${limits.maxResourceBytes} 字节: ${candidate.fileName}`);
+        }
+        const chunks = [];
+        let total = 0;
+        for await (const chunk of response) {
+          total += chunk.length;
+          if (total > limits.maxResourceBytes) {
+            response.destroy();
+            throw new Error(`资源超过单文件大小上限 ${limits.maxResourceBytes} 字节: ${candidate.fileName}`);
+          }
+          chunks.push(chunk);
+        }
+        finish(undefined, {
+          bytes: Buffer.concat(chunks, total),
+          contentType: firstNonEmpty(response.headers["content-type"], candidate.contentType, guessContentType(candidate.fileName)),
+        });
+      } catch (error) {
+        finish(error);
+      }
+    });
+    request.end();
+  });
+}
+
+async function downloadRemoteResource(candidate, args, limits) {
+  let currentUrl = candidate.source;
+  const deadline = Date.now() + limits.timeoutMs;
+  for (let redirects = 0; redirects <= MAX_RESOURCE_REDIRECTS; redirects += 1) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(`资源下载超时（${limits.timeoutMs}ms）: ${candidate.source}`);
+    }
+    const target = await validatedRemoteTarget(currentUrl, args, remainingMs);
+    const afterLookupMs = deadline - Date.now();
+    if (afterLookupMs <= 0) {
+      throw new Error(`资源下载超时（${limits.timeoutMs}ms）: ${candidate.source}`);
+    }
+    const result = await downloadRemoteHop(target, candidate, limits, afterLookupMs);
+    if (!result.redirect) {
+      return result;
+    }
+    if (redirects === MAX_RESOURCE_REDIRECTS) {
+      throw new Error(`资源重定向次数超过上限 ${MAX_RESOURCE_REDIRECTS}: ${candidate.source}`);
+    }
+    currentUrl = result.redirect;
+  }
+  throw new Error(`资源重定向次数超过上限 ${MAX_RESOURCE_REDIRECTS}: ${candidate.source}`);
+}
+
+async function resolveResourceBytes(candidate, args, limits) {
+  if (looksLikeHttpUrl(candidate.source)) {
+    return downloadRemoteResource(candidate, args, limits);
   }
   const filePath = expandHome(candidate.source);
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) {
+    throw new Error(`资源路径必须指向普通文件: ${candidate.source}`);
+  }
+  if (stat.size > limits.maxResourceBytes) {
+    throw new Error(`资源超过单文件大小上限 ${limits.maxResourceBytes} 字节: ${candidate.fileName}`);
+  }
   return { bytes: fs.readFileSync(filePath), contentType: firstNonEmpty(candidate.contentType, guessContentType(filePath)) };
+}
+
+async function resolveResourceBatch(candidates, args) {
+  const limits = resourceLimits();
+  if (candidates.length > limits.maxResources) {
+    throw new Error(`超过资源数量上限 ${limits.maxResources}`);
+  }
+  const resolved = [];
+  let totalBytes = 0;
+  for (const candidate of candidates) {
+    const resource = await resolveResourceBytes(candidate, args, limits);
+    totalBytes += resource.bytes.length;
+    if (totalBytes > limits.maxBatchBytes) {
+      throw new Error(`资源超过批次大小上限 ${limits.maxBatchBytes} 字节`);
+    }
+    resolved.push({ candidate, ...resource });
+  }
+  return resolved;
 }
 
 async function buildUploadFormData(candidates, args) {
   const formData = new FormData();
-  for (const candidate of candidates) {
-    const resolved = await resolveResourceBytes(candidate);
+  for (const resolved of await resolveResourceBatch(candidates, args)) {
     const blob = new Blob([resolved.bytes], { type: resolved.contentType });
-    formData.append("files", blob, candidate.fileName);
+    formData.append("files", blob, resolved.candidate.fileName);
   }
   formData.append("sessionType", "AGENT");
   const sessionId = firstNonEmpty(pick(args, "session-id"), pick(args, "sessionId"));
@@ -902,6 +1194,31 @@ async function uploadResources(candidates, args) {
   }
   const formData = await buildUploadFormData(candidates, args);
   return requestMultipart(uploadUrl, formData);
+}
+
+function confirmedImportTarget(resourceId, directoryPath) {
+  return {
+    knowledgeBaseResourceId: resourceId,
+    directoryPath,
+    requiredArguments: {
+      "confirmed-knowledge-base-resource-id": resourceId,
+      "confirmed-directory-path": directoryPath,
+    },
+  };
+}
+
+function assertConfirmedImportTarget(args, resourceId, directoryPath) {
+  if (args["dry-run"]) {
+    return;
+  }
+  const confirmedResourceId = toPositiveSafeInteger(args["confirmed-knowledge-base-resource-id"]);
+  const confirmedDirectoryPath = firstNonEmpty(args["confirmed-directory-path"]);
+  if (!Number.isSafeInteger(confirmedResourceId) || confirmedResourceId <= 0 || confirmedResourceId !== resourceId) {
+    throw new Error("必须提供与目标一致的 --confirmed-knowledge-base-resource-id");
+  }
+  if (confirmedDirectoryPath !== directoryPath) {
+    throw new Error("必须提供与目标一致的 --confirmed-directory-path");
+  }
 }
 
 // 文件直传知识库支持的类型（后端 byclaw-qa 解析能力：pdf/docx/pptx/xlsx/csv/txt/md）。
@@ -942,11 +1259,15 @@ function buildDocCandidates(args, stdinValue) {
 // 文件直传：POST /datasetController/uploadFiles(multipart) → 逐个 POST /datasetController/build。
 // 后端把原始文件交给 QA 服务解析成 Markdown 再切片/向量化，跳过本地提取。
 async function uploadDocsToDataset(candidates, args) {
-  const resourceId = toNumber(firstPresent(args, ["knowledge-base-resource-id", "resource-id"]));
+  const resourceId = positiveSafeIntegerIfPresent(
+    firstPresent(args, ["knowledge-base-resource-id", "resource-id"]),
+    "--knowledge-base-resource-id",
+  );
   if (!resourceId) {
     throw new Error("文件直传入库必须提供 --knowledge-base-resource-id(知识库资源 ID)；可先用 list-kb 查询并让用户选择");
   }
   const directoryPath = firstNonEmpty(pick(args, "directory-path"), "/");
+  assertConfirmedImportTarget(args, resourceId, directoryPath);
   const uploadUrl = await endpoint("/datasetController/uploadFiles");
   const buildUrl = await endpoint("/datasetController/build");
   if (args["dry-run"]) {
@@ -956,12 +1277,12 @@ async function uploadDocsToDataset(candidates, args) {
       resourceId,
       directoryPath,
       files: candidates.map((candidate) => candidate.fileName),
+      confirmation: confirmedImportTarget(resourceId, directoryPath),
     };
   }
   const formData = new FormData();
-  for (const candidate of candidates) {
-    const resolved = await resolveResourceBytes(candidate);
-    formData.append("files", new Blob([resolved.bytes], { type: resolved.contentType }), candidate.fileName);
+  for (const resolved of await resolveResourceBatch(candidates, args)) {
+    formData.append("files", new Blob([resolved.bytes], { type: resolved.contentType }), resolved.candidate.fileName);
   }
   formData.append("resourceId", String(resourceId));
   formData.append("directoryPath", directoryPath);
@@ -1028,6 +1349,58 @@ function isPathInside(rootPath, candidatePath) {
   return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
 }
 
+const CANONICAL_COLLECTION_KEYS = new Set(["schemaVersion", "title", "source", "backend", "url", "filters", "items"]);
+const CANONICAL_ITEM_KEYS = new Set(["title", "url", "author", "publishTime", "markdown", "fileName"]);
+
+function assertExactKeys(value, allowedKeys, label) {
+  const unexpected = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  if (unexpected.length) {
+    throw new Error(`${label} 包含不支持的${label === "collection-result.json" ? "顶层" : ""}字段: ${unexpected.join(", ")}`);
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} 必须是非空字符串`);
+  }
+}
+
+function validateCanonicalItem(rawItem, index) {
+  const label = `collection-result.json items[${index}]`;
+  if (!rawItem || typeof rawItem !== "object" || Array.isArray(rawItem)) {
+    throw new Error(`${label} 必须是对象`);
+  }
+  assertExactKeys(rawItem, CANONICAL_ITEM_KEYS, label);
+  for (const key of ["title", "url", "markdown", "fileName"]) {
+    requireNonEmptyString(rawItem[key], `${label}.${key}`);
+  }
+  for (const key of ["author", "publishTime"]) {
+    if (rawItem[key] !== undefined && typeof rawItem[key] !== "string") {
+      throw new Error(`${label}.${key} 必须是字符串`);
+    }
+  }
+}
+
+function validateCanonicalCollectionResult(collectionResult) {
+  if (!collectionResult || typeof collectionResult !== "object" || Array.isArray(collectionResult)) {
+    throw new Error("collection-result.json 根节点必须是对象");
+  }
+  assertExactKeys(collectionResult, CANONICAL_COLLECTION_KEYS, "collection-result.json");
+  if (collectionResult.schemaVersion !== "1.0") {
+    throw new Error('collection-result.json schemaVersion 必须是 "1.0"');
+  }
+  for (const key of ["title", "source", "backend", "url"]) {
+    requireNonEmptyString(collectionResult[key], `collection-result.json.${key}`);
+  }
+  if (!collectionResult.filters || typeof collectionResult.filters !== "object" || Array.isArray(collectionResult.filters)) {
+    throw new Error("collection-result.json filters 必须是对象");
+  }
+  if (!Array.isArray(collectionResult.items) || !collectionResult.items.length) {
+    throw new Error("collection-result.json items 必须是非空数组");
+  }
+  collectionResult.items.forEach(validateCanonicalItem);
+}
+
 function resolveCanonicalMarkdownPath(rootDir, rawPath, itemIndex, fieldName) {
   const relativePath = firstNonEmpty(rawPath);
   const label = `collection-result.json items[${itemIndex}].${fieldName}`;
@@ -1057,6 +1430,9 @@ function resolveCanonicalMarkdownPath(rootDir, rawPath, itemIndex, fieldName) {
   }
   if (!fs.statSync(realPath).isFile()) {
     throw new Error(`${label} 必须指向 Markdown 文件: ${relativePath}`);
+  }
+  if (![".md", ".markdown"].includes(path.extname(realPath).toLowerCase())) {
+    throw new Error(`${label} 必须指向扩展名为 .md 或 .markdown 的 Markdown 文件: ${relativePath}`);
   }
 
   return {
@@ -1149,24 +1525,24 @@ function normalizeCollectionResult(collectionResult, args, rawOutput) {
 }
 
 function normalizeCanonicalCollectionResult(collectionResult, args, rawOutput, rootDir) {
-  if (!collectionResult || typeof collectionResult !== "object" || Array.isArray(collectionResult)) {
-    throw new Error("collection-result.json 根节点必须是对象");
-  }
+  validateCanonicalCollectionResult(collectionResult);
   const items = asArray(collectionResult.items)
     .map((item, index) => normalizeCanonicalItem(item, args, index, rootDir));
-  return compactObject({
+  return {
     schemaVersion: collectionResult.schemaVersion,
     title: collectionResult.title,
     source: collectionResult.source,
     backend: collectionResult.backend,
     url: collectionResult.url,
     filters: collectionResult.filters,
-    command: parseJson(args["command-json"], "command-json") || collectionResult.command,
-    outputDir: pick(args, "output-dir", collectionResult.outputDir),
-    rawOutput: firstNonEmpty(pick(args, "raw-output"), readRawOutputFile(args), collectionResult.rawOutput, rawOutput),
-    assetCount: toNumber(pick(args, "asset-count", collectionResult.assetCount)) || 0,
     items,
-  });
+    ...compactObject({
+      command: parseJson(args["command-json"], "command-json") || collectionResult.command,
+      outputDir: pick(args, "output-dir", collectionResult.outputDir),
+      rawOutput: firstNonEmpty(pick(args, "raw-output"), readRawOutputFile(args), rawOutput),
+      assetCount: toNumber(pick(args, "asset-count")) || 0,
+    }),
+  };
 }
 
 function readRawOutputFile(args) {
@@ -1264,7 +1640,10 @@ function buildCollectionResult(args, stdinValue) {
 
 function buildTask(args, stdinJson) {
   const taskJson = parseJson(args["task-json"], "task-json") || stdinJson?.task || {};
-  const knowledgeBaseResourceId = toNumber(pick(args, "knowledge-base-resource-id", taskJson.knowledgeBaseResourceId));
+  const knowledgeBaseResourceId = positiveSafeIntegerIfPresent(
+    pick(args, "knowledge-base-resource-id", taskJson.knowledgeBaseResourceId),
+    "--knowledge-base-resource-id",
+  );
   return compactObject({
     ...taskJson,
     taskId: toNumber(pick(args, "task-id", taskJson.taskId)),
@@ -1283,7 +1662,10 @@ function buildTargetConfig(args, stdinJson, task) {
   const targetConfigJson = parseJson(args["target-config-json"], "target-config-json") || stdinJson?.targetConfig || {};
   return compactObject({
     ...targetConfigJson,
-    knowledgeBaseResourceId: toNumber(pick(args, "knowledge-base-resource-id", targetConfigJson.knowledgeBaseResourceId || task.knowledgeBaseResourceId)),
+    knowledgeBaseResourceId: positiveSafeIntegerIfPresent(
+      pick(args, "knowledge-base-resource-id", targetConfigJson.knowledgeBaseResourceId || task.knowledgeBaseResourceId),
+      "--knowledge-base-resource-id",
+    ),
     knowledgeBaseId: pick(args, "knowledge-base-id", targetConfigJson.knowledgeBaseId || task.knowledgeBaseId),
     knowledgeBaseName: pick(args, "knowledge-base-name", targetConfigJson.knowledgeBaseName || task.knowledgeBaseName),
     directoryPath: firstNonEmpty(pick(args, "directory-path"), targetConfigJson.directoryPath, "/"),
@@ -1445,17 +1827,23 @@ function runNodeJson(scriptPath, args, options = {}) {
         reject(new Error(`by-knowledge-manager upload 失败: ${detail}`));
         return;
       }
+      const expectedActions = options.expectedActions || ["upload"];
+      if (!json || typeof json !== "object" || Array.isArray(json) || json.ok !== true || !expectedActions.includes(json.action)) {
+        reject(new Error(`by-knowledge-manager ${args[0]} 未返回有效 JSON 返回契约`));
+        return;
+      }
       resolve({ code, stdout, stderr, json });
     });
   });
 }
 
 async function uploadMarkdownWithKnowledgeManager(args, payloads) {
-  const resourceId = toNumber(payloads.targetConfig.knowledgeBaseResourceId || payloads.targetConfig.knowledgeBaseId);
+  const resourceId = toPositiveSafeInteger(payloads.targetConfig.knowledgeBaseResourceId || payloads.targetConfig.knowledgeBaseId);
   if (!resourceId) {
     throw new Error("导入知识库必须提供 --knowledge-base-resource-id 或 --knowledge-base-id");
   }
   const directoryPath = firstNonEmpty(payloads.targetConfig.directoryPath, "/");
+  assertConfirmedImportTarget(args, resourceId, directoryPath);
   const managerScript = resolveKnowledgeManagerScript(args);
   const hasCanonicalArtifacts = payloads.markdownFiles.some((item) => Boolean(item[CANONICAL_LOCAL_PATH]));
   if (args["dry-run"]) {
@@ -1466,6 +1854,7 @@ async function uploadMarkdownWithKnowledgeManager(args, payloads) {
       command: "upload",
       resourceId,
       directoryPath,
+      confirmation: confirmedImportTarget(resourceId, directoryPath),
       files: payloads.markdownFiles.map((item) => ({
         fileName: item.fileName,
         source: item[CANONICAL_LOCAL_PATH] ? "validated-canonical" : undefined,
@@ -1478,19 +1867,68 @@ async function uploadMarkdownWithKnowledgeManager(args, payloads) {
   }
 
   const { tempDir, filePaths, reusedFiles, generatedFiles, sessionDirs } = prepareMarkdownUploadFiles(args, payloads);
+  let preserveTempForContinuation = false;
   try {
-    const managerArgs = [
+    const baseManagerArgs = [
       "upload",
       "--resource-id", String(resourceId),
       "--directory-path", directoryPath,
     ];
-    if (args["check-conflicts"]) {
-      managerArgs.push("--check-conflicts");
-    }
     for (const filePath of filePaths) {
-      managerArgs.push("--file-path", filePath);
+      baseManagerArgs.push("--file-path", filePath);
     }
-    const result = await runNodeJson(managerScript, managerArgs);
+    const confirmedOverwritePaths = asArray(args["confirmed-overwrite-path"])
+      .filter((item) => item !== true)
+      .map(String);
+    let result;
+    if (confirmedOverwritePaths.length) {
+      const checked = await runNodeJson(managerScript, [...baseManagerArgs, "--check-conflicts"]);
+      const actualPaths = asArray(checked.json?.overwritePaths).map(String).sort();
+      const confirmedPaths = [...new Set(confirmedOverwritePaths)].sort();
+      if (!checked.json?.needsOverwriteConfirmation || JSON.stringify(actualPaths) !== JSON.stringify(confirmedPaths)) {
+        throw new Error("--confirmed-overwrite-path 与最新冲突路径不一致，已拒绝覆盖");
+      }
+      const updateArgs = [
+        "update-file",
+        "--resource-id", String(resourceId),
+        "--directory-path", directoryPath,
+        "--skip-conflict-check",
+      ];
+      for (const filePath of filePaths) {
+        updateArgs.push("--file-path", filePath);
+      }
+      result = await runNodeJson(managerScript, updateArgs, { expectedActions: ["update-file"] });
+    } else {
+      const managerArgs = [...baseManagerArgs];
+      if (args["check-conflicts"]) {
+        managerArgs.push("--check-conflicts");
+      }
+      result = await runNodeJson(managerScript, managerArgs);
+    }
+    if (result.json?.needsOverwriteConfirmation) {
+      preserveTempForContinuation = Boolean(tempDir);
+      return {
+        action: "confirm-overwrite",
+        conflict: Boolean(result.json.conflict),
+        needsOverwriteConfirmation: true,
+        overwritePaths: asArray(result.json.overwritePaths),
+        resourceId,
+        directoryPath,
+        manager: result.json,
+        continuation: {
+          command: "ingest",
+          markdownFilePaths: filePaths,
+          resourceUploadMustNotBeReplayed: true,
+          requiredArguments: {
+            "knowledge-base-resource-id": resourceId,
+            "directory-path": directoryPath,
+            "confirmed-knowledge-base-resource-id": resourceId,
+            "confirmed-directory-path": directoryPath,
+            "confirmed-overwrite-path": asArray(result.json.overwritePaths),
+          },
+        },
+      };
+    }
     const publicResult = {
       managerScript,
       resourceId,
@@ -1507,7 +1945,7 @@ async function uploadMarkdownWithKnowledgeManager(args, payloads) {
       }
       : { ...publicResult, tempDir, filePaths, reusedFiles, generatedFiles, sessionDirs };
   } finally {
-    if (tempDir && !args["keep-temp"]) {
+    if (tempDir && !args["keep-temp"] && !preserveTempForContinuation) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   }
@@ -1557,6 +1995,31 @@ async function listKnowledgeBases(args, stdinJson = {}) {
   }
   const raw = await requestJson("POST", endpointUrl, payload);
   return { endpoint: endpointUrl, payload, raw, knowledgeBases: normalizeKnowledgeBases(raw) };
+}
+
+async function resolveLegacyKnowledgeBaseId(args, payloads, stdinJson) {
+  if (payloads.targetConfig.knowledgeBaseResourceId) {
+    return payloads.targetConfig.knowledgeBaseResourceId;
+  }
+  const legacyId = positiveSafeIntegerIfPresent(
+    payloads.targetConfig.knowledgeBaseId,
+    "--knowledge-base-id",
+  );
+  if (!legacyId) {
+    return undefined;
+  }
+  const listed = await listKnowledgeBases({ ...args, "page-num": "1", "page-size": "1000" }, stdinJson);
+  const matches = listed.knowledgeBases.filter((item) => (
+    toPositiveSafeInteger(item.resourceId) === legacyId
+    || toPositiveSafeInteger(item.datasetId) === legacyId
+  ));
+  if (matches.length !== 1) {
+    throw new Error(`--knowledge-base-id ${legacyId} 无法唯一解析为知识库资源 ID；请先用 list-kb 查询并改用 --knowledge-base-resource-id`);
+  }
+  const resourceId = matches[0].resourceId;
+  payloads.targetConfig.knowledgeBaseResourceId = resourceId;
+  payloads.task.knowledgeBaseResourceId = resourceId;
+  return resourceId;
 }
 
 function buildPayloads(args, stdinValue) {
@@ -1615,13 +2078,19 @@ async function printHelp() {
       "--bycli-json <json> (legacy compatibility)",
       "--file-url/--image-url/--resource-url <url>",
       "--file-path/--image-path/--resource-path <path>",
+      "--allow-private-resource (explicitly trust private-network resource URLs)",
+      "--confirmed-knowledge-base-resource-id <id> (required for writes)",
+      "--confirmed-directory-path <path> (required for writes)",
+      "--confirmed-overwrite-path <path> (repeatable; resumes a conflict after exact recheck)",
       "stdin JSON 或 Markdown 文本",
     ],
     requiredForImport: ["--knowledge-base-resource-id 或 --knowledge-base-id"],
     examples: [
       "node knowledge-collection-ingest.mjs normalize --collection-result-file /tmp/knowledge-collection-result.json --knowledge-base-resource-id 90001",
-      "node knowledge-collection-ingest.mjs ingest --markdown-file article.md --source-url https://example.com --knowledge-base-resource-id 90001",
-      "node knowledge-collection-ingest.mjs upload-doc --file-path report.pdf --knowledge-base-resource-id 90001 --directory-path /imports",
+      "node knowledge-collection-ingest.mjs ingest --dry-run --markdown-file article.md --knowledge-base-resource-id 90001 --directory-path /imports",
+      "node knowledge-collection-ingest.mjs ingest --markdown-file article.md --knowledge-base-resource-id 90001 --directory-path /imports --confirmed-knowledge-base-resource-id 90001 --confirmed-directory-path /imports",
+      "node knowledge-collection-ingest.mjs ingest --markdown-file article.md --knowledge-base-resource-id 90001 --directory-path /imports --confirmed-knowledge-base-resource-id 90001 --confirmed-directory-path /imports --confirmed-overwrite-path /imports/article.md",
+      "node knowledge-collection-ingest.mjs upload-doc --file-path report.pdf --knowledge-base-resource-id 90001 --directory-path /imports --confirmed-knowledge-base-resource-id 90001 --confirmed-directory-path /imports",
     ],
     backend: await resolveBackendBaseUrl(),
     auth: authSummary(),
@@ -1664,23 +2133,30 @@ async function main() {
   // 分流：图片 / 音频 / 视频走 /chat/uploadFiles；其余文件类型继续走下方 Markdown 入库流程。
   // upload-resource 是显式上传命令，接受任意资源；ingest 自动分流只挑图片 / 音频 / 视频，非媒体文件交给 Markdown 流程。
   const mediaCandidates = resourceCandidates.filter((candidate) => candidate.kind === "image" || candidate.kind === "video" || candidate.kind === "audio");
-  const candidatesToUpload = command === "upload-resource" ? resourceCandidates : mediaCandidates;
-  if (command === "upload-resource" || (command === "ingest" && candidatesToUpload.length)) {
-    if (!candidatesToUpload.length) {
+  if (command === "upload-resource") {
+    if (!resourceCandidates.length) {
       throw new Error("未找到可上传的图片/音频/视频地址。请传 --image-url、指向图片/音频/视频的 --file-url、--file-path，或在 stdin 中提供 fileUrl/imageUrl/downloadUrl/path");
     }
-    const uploaded = await uploadResources(candidatesToUpload, args);
+    const uploaded = await uploadResources(resourceCandidates, args);
     render({
       ok: true,
       action: "upload-resource",
       sessionType: "AGENT",
-      resources: candidatesToUpload,
+      resources: resourceCandidates,
       uploaded,
     });
     return;
   }
 
-  const payloads = buildPayloads(args, stdinValue);
+  let payloads;
+  try {
+    payloads = buildPayloads(args, stdinValue);
+  } catch (error) {
+    if (command === "ingest" && mediaCandidates.length && /未找到可入库的 Markdown/.test(error.message)) {
+      throw new Error("ingest 必须包含可入库的 Markdown；仅上传图片、音频或视频请使用 upload-resource");
+    }
+    throw error;
+  }
 
   if (command === "normalize") {
     render({ ok: true, action: "normalize", summary: summarizePayloads(payloads), payloads });
@@ -1698,8 +2174,27 @@ async function main() {
       render({ ok: true, action: "select-knowledge-base", needsKnowledgeBaseSelection: true, summary: summarizePayloads(payloads), ...listed });
       return;
     }
+    await resolveLegacyKnowledgeBaseId(args, payloads, stdinJson);
+    const resourceId = positiveSafeIntegerIfPresent(
+      payloads.targetConfig.knowledgeBaseResourceId || payloads.targetConfig.knowledgeBaseId,
+      "知识库资源 ID",
+    );
+    const directoryPath = firstNonEmpty(payloads.targetConfig.directoryPath, "/");
+    assertConfirmedImportTarget(args, resourceId, directoryPath);
+    const resourceUpload = mediaCandidates.length ? await uploadResources(mediaCandidates, args) : undefined;
     if (args["dry-run"]) {
       const uploaded = await uploadMarkdownWithKnowledgeManager(args, payloads);
+      if (resourceUpload) {
+        render({
+          ok: true,
+          action: "ingest",
+          dryRun: true,
+          summary: summarizePayloads(payloads),
+          resourceUpload,
+          knowledgeIngest: uploaded,
+        });
+        return;
+      }
       render({
         ok: true,
         action: "ingest",
@@ -1710,6 +2205,29 @@ async function main() {
       return;
     }
     const uploaded = await uploadMarkdownWithKnowledgeManager(args, payloads);
+    if (uploaded.needsOverwriteConfirmation) {
+      render({
+        ok: true,
+        action: "confirm-overwrite",
+        conflict: uploaded.conflict,
+        needsOverwriteConfirmation: true,
+        overwritePaths: uploaded.overwritePaths,
+        summary: summarizePayloads(payloads),
+        continuation: uploaded.continuation,
+        ...(resourceUpload ? { resourceUpload } : {}),
+      });
+      return;
+    }
+    if (resourceUpload) {
+      render({
+        ok: true,
+        action: "ingest",
+        summary: summarizePayloads(payloads),
+        resourceUpload,
+        knowledgeIngest: uploaded,
+      });
+      return;
+    }
     render({ ok: true, action: "ingest", summary: summarizePayloads(payloads), uploaded });
     return;
   }

--- a/middleware/openclaw/skills/knowledge-collection/scripts/knowledge-collection-ingest.test.mjs
+++ b/middleware/openclaw/skills/knowledge-collection/scripts/knowledge-collection-ingest.test.mjs
@@ -31,6 +31,31 @@ function createServer() {
         return;
       }
 
+      if (req.url === "/large.png") {
+        const body = Buffer.alloc(128, 1);
+        res.setHeader("content-type", "image/png");
+        res.setHeader("content-length", String(body.length));
+        res.end(body);
+        return;
+      }
+
+      if (req.url === "/slow.png") {
+        setTimeout(() => {
+          if (!res.destroyed) {
+            res.setHeader("content-type", "image/png");
+            res.end(Buffer.from("slow-png"));
+          }
+        }, 200);
+        return;
+      }
+
+      if (req.url === "/redirect.png") {
+        res.statusCode = 302;
+        res.setHeader("location", "/redirect.png");
+        res.end();
+        return;
+      }
+
       if (req.url === "/doc.pdf" || req.url === "/empty.pdf" || req.url === "/doc.PDF") {
         res.setHeader("content-type", "application/pdf");
         res.end(Buffer.from("pdf-bytes"));
@@ -125,7 +150,7 @@ function createServer() {
   };
 }
 
-function runCli(args, input, port) {
+function runCli(args, input, port, envOverrides = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn("node", [SCRIPT, ...args], {
       cwd: process.cwd(),
@@ -135,6 +160,7 @@ function runCli(args, input, port) {
         REDIS_HOST: "",
         BEYOND_TOKEN: "system-token",
         BY_KNOWLEDGE_MANAGER_SCRIPT: KNOWLEDGE_MANAGER_SCRIPT,
+        ...envOverrides,
       },
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -158,6 +184,31 @@ function runCli(args, input, port) {
       reject(new Error(`CLI timed out: ${args.join(" ")}`));
     }, 10000).unref();
   });
+}
+
+function canonicalItem(markdown, fileName = markdown, overrides = {}) {
+  return {
+    title: "Canonical article",
+    url: "https://example.com/article",
+    author: "Author",
+    publishTime: "2026-07-28T00:00:00Z",
+    markdown,
+    fileName,
+    ...overrides,
+  };
+}
+
+function canonicalCollection(items, overrides = {}) {
+  return {
+    schemaVersion: "1.0",
+    title: "Canonical collection",
+    source: "public-internet",
+    backend: "bycli",
+    url: "https://example.com/collection",
+    filters: {},
+    items,
+    ...overrides,
+  };
 }
 
 async function testHelpUsesMigratedIdentityAndCanonicalInputFirst() {
@@ -184,7 +235,7 @@ async function testCanonicalCollectionResultPreservesMarkdownFrontmatter() {
     source: "xiaohongshu",
     backend: "bycli",
     url: "https://example.com/collection/tea",
-    filters: ["茶叶"],
+    filters: { keywords: ["茶叶"] },
     items: [{
       title: "Tea collection",
       url: "https://example.com/tea",
@@ -206,13 +257,75 @@ async function testCanonicalCollectionResultPreservesMarkdownFrontmatter() {
     assert.equal(normalized?.source, "xiaohongshu");
     assert.equal(normalized?.backend, "bycli");
     assert.equal(normalized?.url, "https://example.com/collection/tea");
-    assert.deepEqual(normalized?.filters, ["茶叶"]);
+    assert.deepEqual(normalized?.filters, { keywords: ["茶叶"] });
     assert.equal(normalized?.items?.[0]?.sourceUrl, "https://example.com/tea");
     assert.equal(normalized?.items?.[0]?.author, "Tea author");
     assert.equal(normalized?.items?.[0]?.publishTime, "2026-07-27T00:00:00Z");
     assert.equal(normalized?.items?.[0]?.localPath, undefined);
     assert.doesNotMatch(result.stdout, new RegExp(fixtureDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.match(normalized?.items?.[0]?.markdown || "", /collection_filters:\n  - 茶叶/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
+async function testCanonicalCollectionResultRejectsInvalidContractShapes() {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-collection-contract-"));
+  const markdownRelativePath = "sanitized/items/article.md";
+  const textRelativePath = "sanitized/items/article.txt";
+  fs.mkdirSync(path.join(fixtureDir, "sanitized/items"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, markdownRelativePath), "# Canonical article");
+  fs.writeFileSync(path.join(fixtureDir, textRelativePath), "not markdown");
+  const cases = [
+    {
+      name: "missing-version",
+      mutate(value) { delete value.schemaVersion; },
+      error: /schemaVersion.*1\.0/,
+    },
+    {
+      name: "wrong-version",
+      mutate(value) { value.schemaVersion = "2.0"; },
+      error: /schemaVersion.*1\.0/,
+    },
+    {
+      name: "extra-top-level",
+      mutate(value) { value.router = "agent-reach"; },
+      error: /不支持的顶层字段.*router/,
+    },
+    {
+      name: "invalid-filters",
+      mutate(value) { value.filters = ["tea"]; },
+      error: /filters.*对象/,
+    },
+    {
+      name: "empty-items",
+      mutate(value) { value.items = []; },
+      error: /items.*非空数组/,
+    },
+    {
+      name: "extra-item-field",
+      mutate(value) { value.items[0].localPath = "/tmp/article.md"; },
+      error: /items\[0\].*不支持的字段.*localPath/,
+    },
+    {
+      name: "non-markdown-artifact",
+      mutate(value) {
+        value.items[0].markdown = textRelativePath;
+        value.items[0].fileName = textRelativePath;
+      },
+      error: /扩展名为 \.md.*Markdown 文件/,
+    },
+  ];
+  try {
+    for (const testCase of cases) {
+      const value = canonicalCollection([canonicalItem(markdownRelativePath)]);
+      testCase.mutate(value);
+      const fixturePath = path.join(fixtureDir, `${testCase.name}.json`);
+      fs.writeFileSync(fixturePath, JSON.stringify(value));
+      const result = await runCli(["normalize", "--collection-result-file", fixturePath], undefined, 0);
+      assert.equal(result.code, 1, `${testCase.name}: ${result.stderr || result.stdout}`);
+      assert.match(String(result.json?.error || ""), testCase.error, testCase.name);
+    }
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
   }
@@ -253,9 +366,9 @@ async function testCanonicalCollectionResultRejectsUnsafeOrMissingMarkdownPaths(
   try {
     for (const testCase of cases) {
       const fixturePath = path.join(fixtureDir, `${testCase.name}.json`);
-      fs.writeFileSync(fixturePath, JSON.stringify({
-        items: [{ title: testCase.name, markdown: testCase.markdown, fileName: testCase.fileName }],
-      }));
+      fs.writeFileSync(fixturePath, JSON.stringify(canonicalCollection([
+        canonicalItem(testCase.markdown, testCase.fileName, { title: testCase.name }),
+      ])));
       const result = await runCli(["normalize", "--collection-result-file", fixturePath], undefined, 0);
       assert.equal(result.code, 1, result.stderr || result.stdout);
       assert.match(String(result.json?.error || ""), testCase.error);
@@ -275,10 +388,9 @@ async function testCanonicalCollectionResultRejectsMismatchedMarkdownAndFileName
   const fixturePath = path.join(fixtureDir, "collection-result.json");
   fs.writeFileSync(path.join(fixtureDir, "a.md"), "# Preview A");
   fs.writeFileSync(path.join(fixtureDir, "b.md"), "# Ingest B");
-  fs.writeFileSync(fixturePath, JSON.stringify({
-    schemaVersion: "1.0",
-    items: [{ title: "Mismatch", markdown: "a.md", fileName: "b.md" }],
-  }));
+  fs.writeFileSync(fixturePath, JSON.stringify(canonicalCollection([
+    canonicalItem("a.md", "b.md", { title: "Mismatch" }),
+  ])));
   try {
     const result = await runCli(["normalize", "--collection-result-file", fixturePath], undefined, 0);
     assert.equal(result.code, 1, result.stderr || result.stdout);
@@ -315,10 +427,9 @@ async function testCanonicalIngestUsesValidatedRootArtifactDespiteDirectoryOverr
   fs.writeFileSync(canonicalMarkdownPath, "# Canonical artifact");
   fs.writeFileSync(overrideMarkdownPath, "# Untrusted override");
   const fixturePath = path.join(fixtureDir, "collection-result.json");
-  fs.writeFileSync(fixturePath, JSON.stringify({
-    schemaVersion: "1.0",
-    items: [{ title: "Canonical", markdown: relativeMarkdownPath, fileName: relativeMarkdownPath }],
-  }));
+  fs.writeFileSync(fixturePath, JSON.stringify(canonicalCollection([
+    canonicalItem(relativeMarkdownPath, relativeMarkdownPath, { title: "Canonical" }),
+  ])));
   try {
     const result = await runCli([
       "ingest",
@@ -332,6 +443,8 @@ async function testCanonicalIngestUsesValidatedRootArtifactDespiteDirectoryOverr
     assert.equal(result.json?.upload?.files?.[0]?.fileName, relativeMarkdownPath);
     assert.equal(result.json?.upload?.files?.[0]?.source, "validated-canonical");
     assert.equal(result.json?.upload?.files?.[0]?.existingPath, undefined);
+    assert.equal(result.json?.upload?.confirmation?.requiredArguments?.["confirmed-knowledge-base-resource-id"], 90001);
+    assert.equal(result.json?.upload?.confirmation?.requiredArguments?.["confirmed-directory-path"], "/");
     assert.doesNotMatch(result.stdout, new RegExp(fixtureDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(result.stdout, new RegExp(overrideDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.equal(result.json?.payloads, undefined);
@@ -354,16 +467,17 @@ async function testCanonicalActualIngestKeepsValidatedPathPrivate() {
   fs.writeFileSync(canonicalMarkdownPath, "# Canonical private artifact");
   fs.writeFileSync(overrideMarkdownPath, "# Untrusted private override");
   const fixturePath = path.join(fixtureDir, "collection-result.json");
-  fs.writeFileSync(fixturePath, JSON.stringify({
-    schemaVersion: "1.0",
-    items: [{ title: "Private", markdown: relativeMarkdownPath, fileName: relativeMarkdownPath }],
-  }));
+  fs.writeFileSync(fixturePath, JSON.stringify(canonicalCollection([
+    canonicalItem(relativeMarkdownPath, relativeMarkdownPath, { title: "Private" }),
+  ])));
   try {
     const result = await runCli([
       "ingest",
       "--collection-result-file", fixturePath,
       "--session-dir", overrideDir,
       "--knowledge-base-resource-id", "90001",
+      "--confirmed-knowledge-base-resource-id", "90001",
+      "--confirmed-directory-path", "/",
     ], undefined, port);
     assert.equal(result.code, 0, result.stderr || result.stdout);
     const upload = server.requests.find((request) => request.url === "/byaiService/datasetController/uploadFiles");
@@ -388,9 +502,9 @@ async function testCanonicalInputPrecedesLegacyAndLegacyRemainsSupported() {
   const legacyPath = path.join(fixtureDir, "legacy.json");
   fs.mkdirSync(path.dirname(canonicalMarkdownPath), { recursive: true });
   fs.writeFileSync(canonicalMarkdownPath, "# Canonical");
-  fs.writeFileSync(canonicalPath, JSON.stringify({
-    items: [{ title: "Canonical", markdown: "sanitized/canonical.md", fileName: "sanitized/canonical.md" }],
-  }));
+  fs.writeFileSync(canonicalPath, JSON.stringify(canonicalCollection([
+    canonicalItem("sanitized/canonical.md", "sanitized/canonical.md", { title: "Canonical" }),
+  ])));
   fs.writeFileSync(legacyPath, JSON.stringify({ items: [{ title: "Legacy", markdown: "# Legacy" }] }));
   try {
     const precedenceResult = await runCli([
@@ -402,6 +516,7 @@ async function testCanonicalInputPrecedesLegacyAndLegacyRemainsSupported() {
     ], undefined, 0);
     assert.equal(precedenceResult.code, 0, precedenceResult.stderr || precedenceResult.stdout);
     assert.equal(precedenceResult.json?.payloads?.collectionResult?.items?.[0]?.markdown, "# Canonical");
+    assert.deepEqual(precedenceResult.json?.payloads?.collectionResult?.filters, {});
 
     const legacyResult = await runCli(["normalize", "--bycli-json-file", legacyPath], undefined, 0);
     assert.equal(legacyResult.code, 0, legacyResult.stderr || legacyResult.stdout);
@@ -425,6 +540,150 @@ async function testLegacyInlineBycliJsonRemainsSupported() {
   assert.equal(result.json?.payloads?.collectionResult?.items?.[0]?.markdown, "# Legacy inline\n\n正文");
 }
 
+async function testRemoteResourceRejectsPrivateAddressByDefault() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const urls = [
+      `http://127.0.0.1:${port}/asset.png`,
+      "http://10.0.0.1/resource.png",
+      "http://169.254.169.254/latest/meta-data.png",
+      "http://198.51.100.1/resource.png",
+      "http://203.0.113.1/resource.png",
+      "http://[::1]/resource.png",
+      "http://[::ffff:7f00:1]/resource.png",
+    ];
+    for (const url of urls) {
+      const result = await runCli(
+        ["upload-resource", "--file-url", url],
+        {},
+        port,
+        { KNOWLEDGE_COLLECTION_RESOURCE_TIMEOUT_MS: "20" },
+      );
+      assert.equal(result.code, 1, `${url}: ${result.stderr || result.stdout}`);
+      assert.match(String(result.json?.error || ""), /私有或保留地址/, url);
+    }
+    const explicitFalse = await runCli(
+      ["upload-resource", "--allow-private-resource=false", "--file-url", `http://127.0.0.1:${port}/asset.png`],
+      {},
+      port,
+    );
+    assert.equal(explicitFalse.code, 1, explicitFalse.stderr || explicitFalse.stdout);
+    assert.match(String(explicitFalse.json?.error || ""), /私有或保留地址/);
+    assert.equal(server.requests.some((request) => request.url === "/asset.png"), false);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testRemoteResourceRejectsUrlCredentials() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://user:password@127.0.0.1:${port}/asset.png`],
+      {},
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /用户名或密码/);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testRemoteResourceLimitsRedirects() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://127.0.0.1:${port}/redirect.png`],
+      {},
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /重定向次数/);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testRemoteResourceEnforcesTimeoutAndSizeLimits() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const oversized = await runCli(
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://127.0.0.1:${port}/large.png`],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_MAX_RESOURCE_BYTES: "16" },
+    );
+    assert.equal(oversized.code, 1, oversized.stderr || oversized.stdout);
+    assert.match(String(oversized.json?.error || ""), /单文件大小上限/);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/chat/uploadFiles"), false);
+
+    const timedOut = await runCli(
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://127.0.0.1:${port}/slow.png`],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_RESOURCE_TIMEOUT_MS: "20" },
+    );
+    assert.equal(timedOut.code, 1, timedOut.stderr || timedOut.stdout);
+    assert.match(String(timedOut.json?.error || ""), /下载超时/);
+
+    const malformedLimitFallsBack = await runCli(
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://127.0.0.1:${port}/large.png`],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_MAX_RESOURCE_BYTES: "16bytes" },
+    );
+    assert.equal(malformedLimitFallsBack.code, 0, malformedLimitFallsBack.stderr || malformedLimitFallsBack.stdout);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testLocalResourceEnforcesFileAndBatchLimits() {
+  const server = createServer();
+  const port = await server.listen();
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-collection-limits-"));
+  const firstPath = path.join(fixtureDir, "first.png");
+  const secondPath = path.join(fixtureDir, "second.png");
+  fs.writeFileSync(firstPath, Buffer.alloc(12, 1));
+  fs.writeFileSync(secondPath, Buffer.alloc(12, 2));
+  try {
+    const oversized = await runCli(
+      ["upload-resource", "--file-path", firstPath],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_MAX_RESOURCE_BYTES: "8" },
+    );
+    assert.equal(oversized.code, 1, oversized.stderr || oversized.stdout);
+    assert.match(String(oversized.json?.error || ""), /单文件大小上限/);
+
+    const tooMany = await runCli(
+      ["upload-resource", "--file-path", firstPath, "--file-path", secondPath],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_MAX_RESOURCES: "1" },
+    );
+    assert.equal(tooMany.code, 1, tooMany.stderr || tooMany.stdout);
+    assert.match(String(tooMany.json?.error || ""), /资源数量上限/);
+
+    const batchTooLarge = await runCli(
+      ["upload-resource", "--file-path", firstPath, "--file-path", secondPath],
+      {},
+      port,
+      { KNOWLEDGE_COLLECTION_MAX_BATCH_BYTES: "16" },
+    );
+    assert.equal(batchTooLarge.code, 1, batchTooLarge.stderr || batchTooLarge.stdout);
+    assert.match(String(batchTooLarge.json?.error || ""), /批次大小上限/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    await server.close();
+  }
+}
+
 async function testMarkdownIngestListsKnowledgeBasesBeforeImport() {
   const server = createServer();
   const port = await server.listen();
@@ -441,11 +700,46 @@ async function testMarkdownIngestListsKnowledgeBasesBeforeImport() {
   }
 }
 
+async function testLegacyKnowledgeBaseIdResolvesToResourceId() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const wrongConfirmation = await runCli(
+      [
+        "ingest",
+        "--knowledge-base-id", "80001",
+        "--confirmed-knowledge-base-resource-id", "80001",
+        "--confirmed-directory-path", "/",
+      ],
+      { content: "# Legacy target" },
+      port,
+    );
+    assert.equal(wrongConfirmation.code, 1, wrongConfirmation.stderr || wrongConfirmation.stdout);
+    assert.match(String(wrongConfirmation.json?.error || ""), /confirmed-knowledge-base-resource-id/);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), false);
+
+    const resolved = await runCli(
+      [
+        "ingest",
+        "--knowledge-base-id", "80001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
+      { content: "# Legacy target" },
+      port,
+    );
+    assert.equal(resolved.code, 0, resolved.stderr || resolved.stdout);
+    assert.equal(resolved.json?.uploaded?.resourceId, 90001);
+  } finally {
+    await server.close();
+  }
+}
+
 async function testImageUrlUploadsToChatFilesAndStops() {
   const server = createServer();
   const port = await server.listen();
   try {
-    const result = await runCli(["ingest", "--session-id", "42"], {
+    const result = await runCli(["upload-resource", "--allow-private-resource", "--session-id", "42"], {
       fileUrl: `http://127.0.0.1:${port}/asset.png`,
       fileName: "asset.png",
     }, port);
@@ -467,7 +761,7 @@ async function testVideoUrlUploadsToChatFilesAndStops() {
   const server = createServer();
   const port = await server.listen();
   try {
-    const result = await runCli(["ingest", "--session-id", "42"], {
+    const result = await runCli(["upload-resource", "--allow-private-resource", "--session-id", "42"], {
       fileUrl: `http://127.0.0.1:${port}/clip.mp4`,
       fileName: "clip.mp4",
     }, port);
@@ -508,7 +802,7 @@ async function testAudioUrlUploadsToChatFilesAndStops() {
   const server = createServer();
   const port = await server.listen();
   try {
-    const result = await runCli(["ingest", "--session-id", "42"], {
+    const result = await runCli(["upload-resource", "--allow-private-resource", "--session-id", "42"], {
       fileUrl: `http://127.0.0.1:${port}/clip.mp3`,
       fileName: "clip.mp3",
     }, port);
@@ -522,12 +816,105 @@ async function testAudioUrlUploadsToChatFilesAndStops() {
   }
 }
 
+async function testMixedMediaAndMarkdownIngestCompletesBothPhases() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--allow-private-resource",
+        "--image-url", `http://127.0.0.1:${port}/asset.png`,
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/imports",
+      ],
+      { title: "Mixed article", content: "# Mixed article\n\n正文" },
+      port,
+    );
+    assert.equal(result.code, 0, result.stderr || result.stdout);
+    assert.equal(result.json?.action, "ingest");
+    assert.equal(result.json?.resourceUpload?.sessionId, 42);
+    assert.equal(result.json?.knowledgeIngest?.manager?.action, "upload");
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/chat/uploadFiles"), true);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), true);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testMixedStdinObjectKeepsMediaAndMarkdown() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--allow-private-resource",
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
+      {
+        title: "Mixed stdin article",
+        content: "# Mixed stdin article\n\n正文",
+        fileUrl: `http://127.0.0.1:${port}/asset.png`,
+        fileName: "asset.png",
+      },
+      port,
+    );
+    assert.equal(result.code, 0, result.stderr || result.stdout);
+    assert.equal(result.json?.action, "ingest");
+    assert.equal(result.json?.resourceUpload?.sessionId, 42);
+    assert.equal(result.json?.knowledgeIngest?.manager?.action, "upload");
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/chat/uploadFiles"), true);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), true);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testMediaOnlyIngestRejectsBeforeUpload() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--allow-private-resource",
+        "--image-url", `http://127.0.0.1:${port}/asset.png`,
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
+      {},
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /upload-resource/);
+    assert.equal(server.requests.some((request) => request.url === "/asset.png"), false);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/chat/uploadFiles"), false);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), false);
+  } finally {
+    await server.close();
+  }
+}
+
 async function testUploadDocViaDatasetController() {
   const server = createServer();
   const port = await server.listen();
   try {
     const result = await runCli(
-      ["upload-doc", "--file-url", `http://127.0.0.1:${port}/doc.pdf`, "--knowledge-base-resource-id", "90001", "--directory-path", "/imports"],
+      [
+        "upload-doc",
+        "--allow-private-resource",
+        "--file-url", `http://127.0.0.1:${port}/doc.pdf`,
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/imports",
+      ],
       {},
       port,
     );
@@ -611,7 +998,13 @@ async function testMarkdownFileIngestSucceeds() {
   fs.writeFileSync(mdPath, "# From File\n\n正文内容");
   try {
     const result = await runCli(
-      ["ingest", "--markdown-file", mdPath, "--knowledge-base-resource-id", "90001"],
+      [
+        "ingest",
+        "--markdown-file", mdPath,
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
       {},
       port,
     );
@@ -637,7 +1030,12 @@ async function testIngestInlineMarkdownUploadsThroughManager() {
   const port = await server.listen();
   try {
     const result = await runCli(
-      ["ingest", "--knowledge-base-resource-id", "90001"],
+      [
+        "ingest",
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
       { content: "# Article\n\n正文" },
       port,
     );
@@ -662,7 +1060,7 @@ async function testUploadResourceFileKindGoesToChatFiles() {
   const port = await server.listen();
   try {
     const result = await runCli(
-      ["upload-resource", "--file-url", `http://127.0.0.1:${port}/doc.pdf`],
+      ["upload-resource", "--allow-private-resource", "--file-url", `http://127.0.0.1:${port}/doc.pdf`],
       {},
       port,
     );
@@ -684,7 +1082,14 @@ async function testUploadDocEmptyUploadItemsErrors() {
   const port = await server.listen();
   try {
     const result = await runCli(
-      ["upload-doc", "--file-url", `http://127.0.0.1:${port}/empty.pdf`, "--knowledge-base-resource-id", "90001"],
+      [
+        "upload-doc",
+        "--allow-private-resource",
+        "--file-url", `http://127.0.0.1:${port}/empty.pdf`,
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
       {},
       port,
     );
@@ -704,7 +1109,14 @@ async function testUploadDocAcceptsUppercaseExtension() {
   const port = await server.listen();
   try {
     const result = await runCli(
-      ["upload-doc", "--file-url", `http://127.0.0.1:${port}/doc.PDF`, "--knowledge-base-resource-id", "90001"],
+      [
+        "upload-doc",
+        "--allow-private-resource",
+        "--file-url", `http://127.0.0.1:${port}/doc.PDF`,
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
       {},
       port,
     );
@@ -717,8 +1129,165 @@ async function testUploadDocAcceptsUppercaseExtension() {
   }
 }
 
+async function testIngestRequiresConfirmedTargetBeforeWrite() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+      ],
+      { content: "# Unconfirmed article" },
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /confirmed-knowledge-base-resource-id/);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), false);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testBareResourceIdFlagsCannotConfirmTarget() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--knowledge-base-resource-id",
+        "--confirmed-knowledge-base-resource-id",
+        "--confirmed-directory-path", "/",
+      ],
+      { content: "# Bare flags must not write" },
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /knowledge-base-resource-id/);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), false);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testUploadDocRequiresConfirmedTargetBeforeWrite() {
+  const server = createServer();
+  const port = await server.listen();
+  try {
+    const result = await runCli(
+      [
+        "upload-doc",
+        "--file-url", `http://127.0.0.1:${port}/doc.pdf`,
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+      ],
+      {},
+      port,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /confirmed-knowledge-base-resource-id/);
+    assert.equal(server.requests.some((request) => request.url === "/byaiService/datasetController/uploadFiles"), false);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testIngestPropagatesOverwriteConfirmationAsNonTerminalState() {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-collection-conflict-manager-"));
+  const managerPath = path.join(fixtureDir, "manager.mjs");
+  fs.writeFileSync(managerPath, `
+const command = process.argv[2];
+process.stdout.write(JSON.stringify(command === "update-file" ? {
+  ok: true,
+  action: "update-file",
+  uploaded: { uploadItems: [{ filePath: "/imports/Conflict-article.md" }] },
+  builds: [{ filePath: "/imports/Conflict-article.md" }],
+} : {
+  ok: true,
+  action: "upload",
+  conflict: true,
+  needsOverwriteConfirmation: true,
+  overwritePaths: ["/imports/Conflict-article.md"],
+}));
+`);
+  let continuationFiles = [];
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--check-conflicts",
+        "--knowledge-manager-script", managerPath,
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/imports",
+      ],
+      { title: "Conflict article", content: "# Conflict article" },
+      0,
+    );
+    assert.equal(result.code, 0, result.stderr || result.stdout);
+    assert.equal(result.json?.action, "confirm-overwrite");
+    assert.equal(result.json?.needsOverwriteConfirmation, true);
+    assert.deepEqual(result.json?.overwritePaths, ["/imports/Conflict-article.md"]);
+    assert.equal(result.json?.uploaded, undefined);
+    continuationFiles = result.json?.continuation?.markdownFilePaths || [];
+    assert.equal(continuationFiles.length, 1);
+    assert.equal(fs.existsSync(continuationFiles[0]), true, "conflict continuation must retain generated Markdown");
+    assert.equal(result.json?.continuation?.requiredArguments?.["knowledge-base-resource-id"], 90001);
+    assert.equal(result.json?.continuation?.requiredArguments?.["confirmed-knowledge-base-resource-id"], 90001);
+
+    const resumed = await runCli(
+      [
+        "ingest",
+        "--knowledge-manager-script", managerPath,
+        "--markdown-file", continuationFiles[0],
+        "--knowledge-base-resource-id", "90001",
+        "--directory-path", "/imports",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/imports",
+        "--confirmed-overwrite-path", "/imports/Conflict-article.md",
+      ],
+      {},
+      0,
+    );
+    assert.equal(resumed.code, 0, resumed.stderr || resumed.stdout);
+    assert.equal(resumed.json?.uploaded?.manager?.action, "update-file");
+  } finally {
+    for (const filePath of continuationFiles) {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
+async function testIngestRejectsSuccessfulManagerExitWithoutJsonContract() {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-collection-empty-manager-"));
+  const managerPath = path.join(fixtureDir, "manager.mjs");
+  fs.writeFileSync(managerPath, "process.exitCode = 0;\n");
+  try {
+    const result = await runCli(
+      [
+        "ingest",
+        "--knowledge-manager-script", managerPath,
+        "--knowledge-base-resource-id", "90001",
+        "--confirmed-knowledge-base-resource-id", "90001",
+        "--confirmed-directory-path", "/",
+      ],
+      { content: "# Manager contract" },
+      0,
+    );
+    assert.equal(result.code, 1, result.stderr || result.stdout);
+    assert.match(String(result.json?.error || ""), /有效 JSON|返回契约/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
 await testHelpUsesMigratedIdentityAndCanonicalInputFirst();
 await testCanonicalCollectionResultPreservesMarkdownFrontmatter();
+await testCanonicalCollectionResultRejectsInvalidContractShapes();
 await testCanonicalCollectionResultRejectsUnsafeOrMissingMarkdownPaths();
 await testCanonicalCollectionResultRejectsMismatchedMarkdownAndFileName();
 await testCollectionResultJsonIsExplicitInlineCompatibilityOnly();
@@ -726,10 +1295,19 @@ await testCanonicalIngestUsesValidatedRootArtifactDespiteDirectoryOverrides();
 await testCanonicalActualIngestKeepsValidatedPathPrivate();
 await testCanonicalInputPrecedesLegacyAndLegacyRemainsSupported();
 await testLegacyInlineBycliJsonRemainsSupported();
+await testRemoteResourceRejectsPrivateAddressByDefault();
+await testRemoteResourceRejectsUrlCredentials();
+await testRemoteResourceLimitsRedirects();
+await testRemoteResourceEnforcesTimeoutAndSizeLimits();
+await testLocalResourceEnforcesFileAndBatchLimits();
 await testMarkdownIngestListsKnowledgeBasesBeforeImport();
+await testLegacyKnowledgeBaseIdResolvesToResourceId();
 await testImageUrlUploadsToChatFilesAndStops();
 await testVideoUrlUploadsToChatFilesAndStops();
 await testAudioUrlUploadsToChatFilesAndStops();
+await testMixedMediaAndMarkdownIngestCompletesBothPhases();
+await testMixedStdinObjectKeepsMediaAndMarkdown();
+await testMediaOnlyIngestRejectsBeforeUpload();
 await testNonMediaFileSkipsUploadAndGoesToMarkdown();
 await testUploadDocViaDatasetController();
 await testUploadDocRejectsUnsupportedType();
@@ -740,4 +1318,9 @@ await testIngestInlineMarkdownUploadsThroughManager();
 await testUploadResourceFileKindGoesToChatFiles();
 await testUploadDocEmptyUploadItemsErrors();
 await testUploadDocAcceptsUppercaseExtension();
+await testIngestRequiresConfirmedTargetBeforeWrite();
+await testBareResourceIdFlagsCannotConfirmTarget();
+await testUploadDocRequiresConfirmedTargetBeforeWrite();
+await testIngestPropagatesOverwriteConfirmationAsNonTerminalState();
+await testIngestRejectsSuccessfulManagerExitWithoutJsonContract();
 console.log("knowledge-collection-ingest tests passed");

--- a/middleware/openclaw/tests/test_agent_reach_skill.py
+++ b/middleware/openclaw/tests/test_agent_reach_skill.py
@@ -240,6 +240,21 @@ class AgentReachSkillContractTest(unittest.TestCase):
         self.assertIn("否则执行 `openclaw browser --browser-profile openclaw start`", cold_start)
         self.assertIn("openclaw browser --browser-profile openclaw stop", skill)
 
+    def test_bycli_groups_priority_and_stop_rules_without_relaxing_ownership(self):
+        skill = BYCLI_SKILL.read_text(encoding="utf-8")
+
+        for phrase in (
+            "## 规则优先级",
+            "用户明确的当前操作范围和安全边界",
+            "STOP / 认证 / 浏览器生命周期规则",
+            "## 认证、人工验证与 STOP",
+            "不得调用 `state`、`tab list`、`get url`",
+            "不得跳转、bind、重试、AutoFix 或重跑 trace",
+            "只使用已经返回的结果",
+            "不得执行 `pkill`、kill-all 或停止共享进程",
+        ):
+            self.assertIn(phrase, skill)
+
     def test_bycli_evals_cover_status_discovery_and_safe_login_boundaries(self):
         evals = json.loads((BYCLI_SKILL.parent / "evals" / "evals.json").read_text(encoding="utf-8"))
         expected = {item["id"]: item["expected_output"] for item in evals["evals"]}
@@ -252,6 +267,11 @@ class AgentReachSkillContractTest(unittest.TestCase):
         self.assertIn("openclaw browser --browser-profile openclaw status", expected[5])
         self.assertIn("/usr/local/bin/start-chrome.sh", expected[5])
         self.assertIn("不得代填或提交凭据", expected[8])
+        self.assertIn("可点击链接", expected[12])
+        self.assertIn("不得调用 get url、state、tab list", expected[13])
+        self.assertIn("不需要", expected[14])
+        self.assertIn("/usr/local/bin/start-chrome.sh 存在且可执行", expected[15])
+        self.assertIn("openclaw browser --browser-profile openclaw start", expected[15])
 
 
 if __name__ == "__main__":

--- a/middleware/openclaw/tests/test_knowledge_collection_skill.py
+++ b/middleware/openclaw/tests/test_knowledge_collection_skill.py
@@ -199,6 +199,27 @@ class KnowledgeCollectionSkillContractTest(unittest.TestCase):
         self.assertIn(f"]({relative_path})", skill)
         self.assertTrue(bridge_path.is_file(), relative_path)
 
+    def test_agent_reach_enterprise_collection_routes_to_source_bridges(self):
+        collection_skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        agent_reach = (SKILLS_ROOT / "agent-reach" / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("企业来源的采集、归档、批量搜索或入库请求", agent_reach)
+        self.assertIn("采集编排器 `knowledge-collection`", agent_reach)
+        self.assertIn("不得作为公共互联网任务交给 `bycli`", agent_reach)
+
+        bridges = {
+            "references/sources/wecom-wecomcli.md": "`wecomcli` skill",
+            "references/sources/feishu-fws.md": "`fws` skill",
+        }
+        for relative_path, child_skill in bridges.items():
+            with self.subTest(relative_path=relative_path):
+                bridge = (SKILL_ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertIn(f"]({relative_path})", collection_skill)
+                self.assertIn("委派采集模式", bridge)
+                self.assertIn(child_skill, bridge)
+                self.assertIn("`knowledge-collection` 负责", bridge)
+                self.assertIn("浏览器、curl、直接 HTTP/API", bridge)
+
     def test_child_skill_routes_resolve_to_expected_frontmatter_names(self):
         for relative_path, expected_name in CHILD_SKILLS.items():
             with self.subTest(relative_path=relative_path):


### PR DESCRIPTION
## 变更内容
- 强化知识采集入库流程及产物校验。
- 增加企业微信、飞书知识采集 runners 与来源参考。
- 补充采集 runner、skill contract 和安全边界测试。

## 关联 Issue
Closes #106

## 验证
- Python skill 合约测试：44 passed，14 subtests passed
- 企业采集 runner Node 测试通过
- `git diff --check` 通过
- 知识入库脚本完整 Node 测试受本地缺少 `@byclaw/by-framework` 依赖影响，未能运行