### PR TITLE
fix(skill): support UTF-8 zip entry names

### DIFF
--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillDocParser.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillDocParser.java
@@ -1,6 +1,8 @@
 package com.iwhalecloud.byai.state.application.service.session;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -38,17 +40,80 @@ final class ByClawSkillDocParser {
         if (!frontMatterText.hasFrontMatter()) {
             return null;
         }
-        String[] lines = frontMatterText.text().split("\\R");
+        String[] lines = frontMatterText.text().split("\\R", -1);
         for (int i = frontMatterText.startLine(); i < lines.length; i++) {
             String line = StringUtils.trimToEmpty(lines[i]);
             if ("---".equals(line) || "...".equals(line)) {
                 break;
             }
             if (StringUtils.startsWithIgnoreCase(line, key + ":")) {
-                return StringUtils.strip(StringUtils.substringAfter(line, ":"), "\"' ");
+                String inlineValue = StringUtils.strip(StringUtils.substringAfter(line, ":"), "\"' ");
+                if (StringUtils.isBlank(inlineValue) || isYamlBlockScalarHeader(inlineValue)
+                    || isSymbolOnly(inlineValue)) {
+                    return extractIndentedValue(lines, i + 1, leadingWhitespaceCount(lines[i]));
+                }
+                return sanitizeDescription(inlineValue);
             }
         }
         return null;
+    }
+
+    /**
+     * Reads a YAML block scalar (description: &gt; / |) and the compatible historical form where the value line
+     * contains only symbols. The value ends at the next front-matter delimiter or sibling top-level property.
+     */
+    private static String extractIndentedValue(String[] lines, int startLine, int keyIndent) {
+        List<String> valueLines = new ArrayList<>();
+        for (int i = startLine; i < lines.length; i++) {
+            String trimmed = StringUtils.trimToEmpty(lines[i]);
+            if ("---".equals(trimmed) || "...".equals(trimmed)) {
+                break;
+            }
+            if (StringUtils.isNotBlank(trimmed) && leadingWhitespaceCount(lines[i]) <= keyIndent) {
+                break;
+            }
+            valueLines.add(trimmed);
+        }
+        if (valueLines.isEmpty()) {
+            return null;
+        }
+        // Skill descriptions are displayed as plain summaries. Fold both YAML scalar styles into stable text so
+        // formatting-only line wraps do not leak into the resource card or database description.
+        return sanitizeDescription(String.join("\n", valueLines));
+    }
+
+    private static String sanitizeDescription(String description) {
+        if (StringUtils.isBlank(description)) {
+            return null;
+        }
+        List<String> contentLines = description.lines()
+            .map(StringUtils::trimToEmpty)
+            .collect(Collectors.toCollection(ArrayList::new));
+        while (!contentLines.isEmpty()
+            && (StringUtils.isBlank(contentLines.get(0)) || isSymbolOnly(contentLines.get(0)))) {
+            contentLines.remove(0);
+        }
+        String result = contentLines.stream()
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.joining(" "));
+        return StringUtils.trimToNull(result);
+    }
+
+    private static boolean isYamlBlockScalarHeader(String value) {
+        String marker = StringUtils.trimToEmpty(StringUtils.substringBefore(value, "#"));
+        return marker.matches("[>|][+\\-1-9]*");
+    }
+
+    private static boolean isSymbolOnly(String value) {
+        return StringUtils.isNotBlank(value) && value.codePoints().noneMatch(Character::isLetterOrDigit);
+    }
+
+    private static int leadingWhitespaceCount(String line) {
+        int index = 0;
+        while (index < line.length() && Character.isWhitespace(line.charAt(index))) {
+            index++;
+        }
+        return index;
     }
 
     private static String stripFrontMatter(String content) {

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillResourceApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillResourceApplicationService.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -92,6 +93,10 @@ public class ByClawSkillResourceApplicationService {
     private static final String EXTERNAL_RESOURCE_ROOT = "/byclaw/resource";
 
     private static final String SKILL_DOC_FILE_NAME = "SKILL.md";
+
+    private static final String ZIP_ENTRY_NAME_PRIMARY_ENCODING = "GBK";
+
+    private static final String ZIP_ENTRY_NAME_FALLBACK_ENCODING = StandardCharsets.UTF_8.name();
 
     private static final int THIRD_PARTY_DOWNLOAD_TIMEOUT_MILLIS = 15_000;
 
@@ -1242,8 +1247,34 @@ public class ByClawSkillResourceApplicationService {
     }
 
     private List<ZipEntryInfo> readZipEntries(byte[] bytes) {
+        List<ZipEntryInfo> entries;
+        try {
+            entries = readZipEntries(bytes, ZIP_ENTRY_NAME_PRIMARY_ENCODING);
+        }
+        catch (CharacterCodingException primaryException) {
+            logger.debug("Skill 资源包 entry 名无法按 {} 解码，使用 {} 重试",
+                ZIP_ENTRY_NAME_PRIMARY_ENCODING, ZIP_ENTRY_NAME_FALLBACK_ENCODING);
+            try {
+                entries = readZipEntries(bytes, ZIP_ENTRY_NAME_FALLBACK_ENCODING);
+            }
+            catch (IOException fallbackException) {
+                fallbackException.addSuppressed(primaryException);
+                throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), fallbackException);
+            }
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), e);
+        }
+        if (entries.isEmpty()) {
+            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.empty"));
+        }
+        return entries;
+    }
+
+    private List<ZipEntryInfo> readZipEntries(byte[] bytes, String encoding) throws IOException {
         List<ZipEntryInfo> entries = new ArrayList<>();
-        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(new ByteArrayInputStream(bytes), "GBK", true, true)) {
+        try (ZipArchiveInputStream zin =
+            new ZipArchiveInputStream(new ByteArrayInputStream(bytes), encoding, true, true)) {
             ArchiveEntry entry;
             while ((entry = zin.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -1255,12 +1286,6 @@ public class ByClawSkillResourceApplicationService {
                 }
                 entries.add(new ZipEntryInfo(normalized, zin.readAllBytes()));
             }
-        }
-        catch (IOException e) {
-            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), e);
-        }
-        if (entries.isEmpty()) {
-            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.empty"));
         }
         return entries;
     }

--- a/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillUploadApplicationService.java
+++ b/byclaw-be/src/main/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillUploadApplicationService.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -57,8 +59,11 @@ public class ByClawSkillUploadApplicationService {
 
     private static final String IGNORED_FILE_DS_STORE = ".DS_Store";
 
-    /** 兼容 Windows / 常见压缩工具未设置 UTF-8 标记时的中文 entry 名。 */
-    private static final String ZIP_ENTRY_NAME_FALLBACK_ENCODING = "GBK";
+    /** 兼容 Windows / 常见中文压缩工具未设置 UTF-8 标记时的 GBK entry 名。 */
+    private static final String ZIP_ENTRY_NAME_PRIMARY_ENCODING = "GBK";
+
+    /** 兼容 macOS 等按 UTF-8 写入 entry 名、但遗漏语言编码标志的压缩包。 */
+    private static final String ZIP_ENTRY_NAME_FALLBACK_ENCODING = StandardCharsets.UTF_8.name();
 
     @Autowired
     private UserFS userFS;
@@ -160,9 +165,34 @@ public class ByClawSkillUploadApplicationService {
     }
 
     private List<ParsedEntry> parseZipEntries(MultipartFile zipFile) {
+        List<ParsedEntry> result;
+        try {
+            result = readZipEntries(zipFile, ZIP_ENTRY_NAME_PRIMARY_ENCODING);
+        }
+        catch (CharacterCodingException primaryException) {
+            logger.debug("skill zip entry 名无法按 GBK 解码，使用 UTF-8 重试, filename={}",
+                lastPathSegment(zipFile.getOriginalFilename()));
+            try {
+                result = readZipEntries(zipFile, ZIP_ENTRY_NAME_FALLBACK_ENCODING);
+            }
+            catch (IOException fallbackException) {
+                fallbackException.addSuppressed(primaryException);
+                throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), fallbackException);
+            }
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), e);
+        }
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.empty"));
+        }
+        return result;
+    }
+
+    private List<ParsedEntry> readZipEntries(MultipartFile zipFile, String entryNameEncoding) throws IOException {
         List<ParsedEntry> result = new ArrayList<>();
-        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(zipFile.getInputStream(),
-            ZIP_ENTRY_NAME_FALLBACK_ENCODING, true, true)) {
+        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(zipFile.getInputStream(), entryNameEncoding, true,
+            true)) {
             ArchiveEntry zipEntry;
             while ((zipEntry = zin.getNextEntry()) != null) {
                 if (zipEntry.isDirectory()) {
@@ -175,12 +205,6 @@ public class ByClawSkillUploadApplicationService {
                 byte[] content = zin.readAllBytes();
                 result.add(new ParsedEntry(normalized, content));
             }
-        }
-        catch (IOException e) {
-            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.read.failed"), e);
-        }
-        if (result.isEmpty()) {
-            throw new IllegalArgumentException(I18nUtil.get("byclaw.skill.zip.empty"));
         }
         return result;
     }

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillDocParserTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillDocParserTest.java
@@ -1,0 +1,99 @@
+package com.iwhalecloud.byai.state.application.service.session;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ByClawSkillDocParserTest {
+
+    @Test
+    void shouldReadFoldedYamlDescriptionBodyInsteadOfBlockMarker() {
+        String skillDoc = """
+            ---
+            name: ppt-master
+            description: >
+              AI-driven presentation workflow for generating editable PPTX decks and
+              slides, reconstructing page visuals and filling native PPTX templates.
+            metadata:
+              version: "4.8.0-baiying.1"
+            ---
+            # PPT Master
+            """;
+
+        assertEquals(
+            "AI-driven presentation workflow for generating editable PPTX decks and slides, "
+                + "reconstructing page visuals and filling native PPTX templates.",
+            ByClawSkillDocParser.extractDescription(skillDoc));
+    }
+
+    @Test
+    void shouldReadIndentedDescriptionWhenYamlValueIsEmpty() {
+        String skillDoc = """
+            ---
+            name: ppt-master-0.1
+            description:
+              AI-driven presentation workflow for generating editable PPTX decks and slides,
+              reconstructing page visuals and creating reusable workspaces.
+              也用于用户提出制作、生成、重构或美化 PPT 的场景。
+            metadata:
+              version: "4.8.0-baiying.1"
+            ---
+            # PPT Master
+            """;
+
+        assertEquals(
+            "AI-driven presentation workflow for generating editable PPTX decks and slides, "
+                + "reconstructing page visuals and creating reusable workspaces. "
+                + "也用于用户提出制作、生成、重构或美化 PPT 的场景。",
+            ByClawSkillDocParser.extractDescription(skillDoc));
+    }
+
+    @Test
+    void shouldSkipLeadingSymbolOnlyLinesInDescriptionBody() {
+        String skillDoc = """
+            ---
+            name: symbol-prefix
+            description: |
+              ***
+              >>>
+              Generate an editable presentation from the user's source material.
+              Preserve charts and tables as native objects.
+            ---
+            # Symbol Prefix
+            """;
+
+        assertEquals(
+            "Generate an editable presentation from the user's source material. "
+                + "Preserve charts and tables as native objects.",
+            ByClawSkillDocParser.extractDescription(skillDoc));
+    }
+
+    @Test
+    void shouldFallbackToMarkdownBodyWhenDescriptionContainsOnlySymbols() {
+        String skillDoc = """
+            ---
+            name: body-fallback
+            description: >>>
+            ---
+            # Body Fallback
+            Generate reports from structured data.
+            Keep the result editable.
+            """;
+
+        assertEquals("Generate reports from structured data. Keep the result editable.",
+            ByClawSkillDocParser.extractDescription(skillDoc));
+    }
+
+    @Test
+    void shouldKeepExistingInlineDescriptionBehavior() {
+        String skillDoc = """
+            ---
+            name: inline-description
+            description: Generate editable PPTX presentations.
+            ---
+            # Inline Description
+            """;
+
+        assertEquals("Generate editable PPTX presentations.", ByClawSkillDocParser.extractDescription(skillDoc));
+    }
+}

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillResourceApplicationServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillResourceApplicationServiceTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -884,6 +886,19 @@ class ByClawSkillResourceApplicationServiceTest {
         }
     }
 
+    @Test
+    void inspectSkillPackage_acceptsUtf8ChineseEntryNamesWithoutLanguageEncodingFlag() {
+        MockMultipartFile uploadFile = new MockMultipartFile("file", "ppt-master-0.1.zip", "application/zip",
+            utf8UnflaggedSkillZipBytes());
+
+        ByClawSkillResourceApplicationService.SkillPackageMetadata metadata =
+            service.inspectSkillPackage(uploadFile);
+
+        assertThat(metadata.skillName()).isEqualTo("ppt-master");
+        assertThat(metadata.skillCode()).isEqualTo("ppt-master");
+        assertThat(metadata.skillDesc()).isEqualTo("AI 驱动的演示文稿生成技能");
+    }
+
     private byte[] skillZipBytes(String skillName) {
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -891,6 +906,33 @@ class ByClawSkillResourceApplicationServiceTest {
                 zip.putNextEntry(new ZipEntry(skillName + "/SKILL.md"));
                 zip.write(("## " + skillName + "\n用于测试的技能描述").getBytes(java.nio.charset.StandardCharsets.UTF_8));
                 zip.closeEntry();
+            }
+            return out.toByteArray();
+        }
+        catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private byte[] utf8UnflaggedSkillZipBytes() {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (ZipArchiveOutputStream zip = new ZipArchiveOutputStream(out)) {
+                zip.setEncoding(StandardCharsets.UTF_8.name());
+                zip.setUseLanguageEncodingFlag(false);
+                zip.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.NEVER);
+
+                ZipArchiveEntry skillDoc = new ZipArchiveEntry("ppt-master/SKILL.md");
+                zip.putArchiveEntry(skillDoc);
+                zip.write(("---\nname: ppt-master\ndescription: >\n  AI 驱动的演示文稿生成技能\n---\n")
+                    .getBytes(StandardCharsets.UTF_8));
+                zip.closeArchiveEntry();
+
+                ZipArchiveEntry chineseEntry =
+                    new ZipArchiveEntry("ppt-master/templates/brands/中汽研/design_spec.md");
+                zip.putArchiveEntry(chineseEntry);
+                zip.write("template".getBytes(StandardCharsets.UTF_8));
+                zip.closeArchiveEntry();
             }
             return out.toByteArray();
         }

--- a/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillUploadApplicationServiceTest.java
+++ b/byclaw-be/src/test/java/com/iwhalecloud/byai/state/application/service/session/ByClawSkillUploadApplicationServiceTest.java
@@ -11,6 +11,8 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 
 import com.iwhalecloud.byai.common.i18n.I18nUtil;
@@ -179,6 +181,22 @@ class ByClawSkillUploadApplicationServiceTest {
     }
 
     @Test
+    void shouldAcceptUtf8ChineseEntryNamesWithoutLanguageEncodingFlag() {
+        MultipartFile zip = buildUtf8ZipWithoutLanguageEncodingFlag("ppt-master.zip",
+            "ppt-master/SKILL.md", "# PPT Master",
+            "ppt-master/templates/brands/中汽研/design_spec.md", "brand spec");
+        when(skillPathResolver.resolveSkillRootPrefix(USER_CODE, RESOURCE_ID)).thenReturn(AGENT_PREFIX);
+
+        ByClawSkillDto dto = service.uploadSkillZip(USER_CODE, RESOURCE_ID, zip);
+
+        assertEquals("ppt-master", dto.getSkillName());
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userFS, atLeastOnce()).write(any(InputStream.class), anyLong(), anyString(), pathCaptor.capture());
+        assertTrue(pathCaptor.getAllValues()
+            .contains(AGENT_PREFIX + "ppt-master/templates/brands/中汽研/design_spec.md"));
+    }
+
+    @Test
     void shouldRejectZipWithMultipleSkillDocs() {
         // 两个顶层 skill 目录都存在 SKILL.md，仍按单 skill zip 判定违规。
         MultipartFile zip = buildZip("skill.zip",
@@ -318,6 +336,27 @@ class ByClawSkillUploadApplicationServiceTest {
                 zos.putNextEntry(new ZipEntry(entries[i]));
                 zos.write(entries[i + 1].getBytes());
                 zos.closeEntry();
+            }
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return new MockMultipartFile("file", filename, "application/zip", buf.toByteArray());
+    }
+
+    private MultipartFile buildUtf8ZipWithoutLanguageEncodingFlag(String filename, String... entries) {
+        if (entries.length % 2 != 0) {
+            throw new IllegalArgumentException("entries 必须成对");
+        }
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(buf)) {
+            zos.setEncoding("UTF-8");
+            zos.setUseLanguageEncodingFlag(false);
+            zos.setCreateUnicodeExtraFields(ZipArchiveOutputStream.UnicodeExtraFieldPolicy.NEVER);
+            for (int i = 0; i < entries.length; i += 2) {
+                zos.putArchiveEntry(new ZipArchiveEntry(entries[i]));
+                zos.write(entries[i + 1].getBytes());
+                zos.closeArchiveEntry();
             }
         }
         catch (IOException e) {


### PR DESCRIPTION
## 修改内容

- 兼容未标记 UTF-8 的中文 ZIP 条目名称。
- SKILL.md 描述首行仅含符号时，从正文提取描述。

## 原因

部分技能包在 macOS 等环境中使用 UTF-8 条目名但未写入语言编码标志，原有 GBK 解码会导致导入失败。

## 验证

- `ByClawSkillDocParserTest`
- `ByClawSkillResourceApplicationServiceTest`
- `ByClawSkillUploadApplicationServiceTest`
